### PR TITLE
Don't send notifications to un-paired peers when READ_ENC set

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -137,7 +137,7 @@ uint16_t NimBLECharacteristic::getHandle() {
 } // getHandle
 
 
-uint8_t NimBLECharacteristic::getProperties() {
+uint16_t NimBLECharacteristic::getProperties() {
     return m_properties;
 } // getProperties
 

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -346,6 +346,9 @@ void NimBLECharacteristic::notify(bool is_notification) {
 
     std::string value = getValue();
     size_t length = value.length();
+    bool reqSec = (m_properties & BLE_GATT_CHR_F_READ_AUTHEN) ||
+                  (m_properties & BLE_GATT_CHR_F_READ_AUTHOR) ||
+                  (m_properties & BLE_GATT_CHR_F_READ_ENC);
     int rc = 0;
 
     for (auto &it : p2902->m_subscribedVec) {
@@ -353,8 +356,16 @@ void NimBLECharacteristic::notify(bool is_notification) {
 
         // check if connected and subscribed
         if(_mtu == 0 || it.sub_val == 0) {
-            //NIMBLE_LOGD(LOG_TAG, "peer not connected");
             continue;
+        }
+
+        // check if security requirements are satisfied
+        if(reqSec) {
+            struct ble_gap_conn_desc desc;
+            rc = ble_gap_conn_find(it.conn_id, &desc);
+            if(rc != 0 || !desc.sec_state.encrypted) {
+                continue;
+            }
         }
 
         if (length > _mtu - 3) {

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -107,7 +107,7 @@ private:
     ~NimBLECharacteristic();
 
     NimBLEService*  getService();
-    uint8_t         getProperties();
+    uint16_t        getProperties();
     void            setSubscribe(struct ble_gap_event *event);
     static int      handleGapEvent(uint16_t conn_handle, uint16_t attr_handle,
                                    struct ble_gatt_access_ctxt *ctxt, void *arg);

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -181,8 +181,8 @@ int NimBLEServer::disconnect(uint16_t connId, uint8_t reason) {
                                     NimBLEUtils::returnCodeToString(rc));
     }
 
-    return rc;
     NIMBLE_LOGD(LOG_TAG, "<< disconnect()");
+    return rc;
 } // disconnect
 
 
@@ -276,6 +276,7 @@ size_t NimBLEServer::getConnectedCount() {
             for(auto &it : server->m_notifyChrVec) {
                 if(it->getHandle() == event->subscribe.attr_handle) {
                     if((it->getProperties() & BLE_GATT_CHR_F_READ_AUTHEN) ||
+                       (it->getProperties() & BLE_GATT_CHR_F_READ_AUTHOR) ||
                        (it->getProperties() & BLE_GATT_CHR_F_READ_ENC))
                     {
                         rc = ble_gap_conn_find(event->subscribe.conn_handle, &desc);
@@ -340,7 +341,7 @@ size_t NimBLEServer::getConnectedCount() {
         } // BLE_GAP_EVENT_REPEAT_PAIRING
 
         case BLE_GAP_EVENT_ENC_CHANGE: {
-            rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
+            rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
             if(rc != 0) {
                 return BLE_ATT_ERR_INVALID_HANDLE;
             }


### PR DESCRIPTION
If read encryption is applied to a characteristic the server should not allow notifications of it's value to be sent to peers that have not paired with the server.

* Also added minor bugfixes