### PR TITLE
Add feature: remove service

### DIFF
--- a/docs/Improvements_and_updates.md
+++ b/docs/Improvements_and_updates.md
@@ -43,6 +43,14 @@ as a type specified by the user.
 A new method `NimBLEServer::advertiseOnDisconnect(bool)` has been implemented to control this, true(default) = enabled.  
 <br/>
 
+`NimBLEServer::removeService` takes an additional parameter `bool deleteSvc` that if true will delete the service  
+and all characteristics / descriptors belonging to it and invalidating any pointers to them.  
+
+If false the service is only removed from visibility by clients. The pointers to the service and  
+it's characteristics / descriptors will remain valid and the service can be re-added in the future  
+using `NimBLEServer::addService`.  
+<br/>
+
 # Client  
 
 NimBLERemoteCharacteristic::readValue(time_t\*, bool)  

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -63,6 +63,7 @@ NimBLEAdvertising::NimBLEAdvertising() {
  */
 void NimBLEAdvertising::addServiceUUID(const NimBLEUUID &serviceUUID) {
     m_serviceUUIDs.push_back(serviceUUID);
+    m_advDataSet = false;
 } // addServiceUUID
 
 
@@ -72,6 +73,22 @@ void NimBLEAdvertising::addServiceUUID(const NimBLEUUID &serviceUUID) {
  */
 void NimBLEAdvertising::addServiceUUID(const char* serviceUUID) {
     addServiceUUID(NimBLEUUID(serviceUUID));
+} // addServiceUUID
+
+
+/**
+ * @brief Add a service uuid to exposed list of services.
+ * @param [in] serviceUUID The UUID of the service to expose.
+ */
+void NimBLEAdvertising::removeServiceUUID(const NimBLEUUID &serviceUUID) {
+    //m_serviceUUIDs.erase(std::remove_if(m_serviceUUIDs.begin(), m_serviceUUIDs.end(),[serviceUUID](const NimBLEUUID &s) {return serviceUUID == s;}), m_serviceUUIDs.end());
+    for(auto it = m_serviceUUIDs.begin(); it != m_serviceUUIDs.end(); ++it) {
+        if((*it) == serviceUUID) {
+            m_serviceUUIDs.erase(it);
+            break;
+        }
+    }
+    m_advDataSet = false;
 } // addServiceUUID
 
 

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -75,6 +75,7 @@ public:
     NimBLEAdvertising();
     void addServiceUUID(const NimBLEUUID &serviceUUID);
     void addServiceUUID(const char* serviceUUID);
+    void removeServiceUUID(const NimBLEUUID &serviceUUID);
     void start();
     void stop();
     void setAppearance(uint16_t appearance);

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -58,6 +58,9 @@ NimBLECharacteristic::NimBLECharacteristic(const NimBLEUUID &uuid, uint16_t prop
  * @brief Destructor.
  */
 NimBLECharacteristic::~NimBLECharacteristic() {
+    for(auto &it : m_dscVec) {
+        delete it;
+    }
 } // ~NimBLECharacteristic
 
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -71,7 +71,6 @@ NimBLESecurityCallbacks*    NimBLEDevice::m_securityCallbacks = nullptr;
     if(NimBLEDevice::m_pServer == nullptr) {
         NimBLEDevice::m_pServer = new NimBLEServer();
         ble_gatts_reset();
-        ble_svc_gap_init();
         ble_svc_gatt_init();
     }
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -71,6 +71,7 @@ NimBLESecurityCallbacks*    NimBLEDevice::m_securityCallbacks = nullptr;
     if(NimBLEDevice::m_pServer == nullptr) {
         NimBLEDevice::m_pServer = new NimBLEServer();
         ble_gatts_reset();
+        ble_svc_gap_init();
         ble_svc_gatt_init();
     }
 

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -146,8 +146,14 @@ void NimBLEServer::start() {
 
     NIMBLE_LOGI(LOG_TAG, "Service changed characterisic handle: %d", m_svcChgChrHdl);
 */
-    // Build a vector of characteristics with Notify / Indicate capabilities for event handling
+    // Get the assigned service handles and build a vector of characteristics 
+    // with Notify / Indicate capabilities for event handling
     for(auto &svc : m_svcVec) {
+        rc = ble_gatts_find_svc(&svc->getUUID().getNative()->u, &svc->m_handle);
+        if(rc != 0) {
+            abort();
+        }
+
         for(auto &chr : svc->m_chrVec) {
             // if Notify / Indicate is enabled but we didn't create the descriptor
             // we do it now.

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -463,6 +463,8 @@ void NimBLEServer::removeService(NimBLEService* service) {
         return;
     }
 
+    ble_svc_gatt_changed(service->getHandle(), 0xffff);
+
     for(auto it = m_svcVec.begin(); it != m_svcVec.end(); ++it) {
         if ((*it)->getHandle() == service->getHandle()) {
             delete *it;
@@ -471,7 +473,7 @@ void NimBLEServer::removeService(NimBLEService* service) {
         }
     }
 
-    ble_svc_gatt_changed(0x0001, 0xffff);
+
 }
 
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -41,7 +41,8 @@ public:
     NimBLEService*         createService(const char* uuid);
     NimBLEService*         createService(const NimBLEUUID &uuid, uint32_t numHandles=15,
                                          uint8_t inst_id=0);
-    void                   removeService(NimBLEService* service);
+    void                   removeService(NimBLEService* service, bool deleteSvc = false);
+    void                   addService(NimBLEService* service);
     NimBLEAdvertising*     getAdvertising();
     void                   setCallbacks(NimBLEServerCallbacks* pCallbacks);
     void                   startAdvertising();
@@ -60,6 +61,7 @@ public:
 
 private:
     NimBLEServer();
+    ~NimBLEServer();
     friend class           NimBLECharacteristic;
     friend class           NimBLEDevice;
     friend class           NimBLEAdvertising;
@@ -76,6 +78,7 @@ private:
     std::vector<NimBLECharacteristic*> m_notifyChrVec;
 
     static int             handleGapEvent(struct ble_gap_event *event, void *arg);
+    void                   resetGATT();
 }; // NimBLEServer
 
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -66,6 +66,7 @@ private:
 
     bool                   m_gattsStarted;
     bool                   m_advertiseOnDisconnect;
+    bool                   m_svcChanged;
     NimBLEServerCallbacks* m_pServerCallbacks;
     std::vector<uint16_t>  m_connectedPeersVec;
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -41,6 +41,7 @@ public:
     NimBLEService*         createService(const char* uuid);
     NimBLEService*         createService(const NimBLEUUID &uuid, uint32_t numHandles=15,
                                          uint8_t inst_id=0);
+    void                   removeService(NimBLEService* service);
     NimBLEAdvertising*     getAdvertising();
     void                   setCallbacks(NimBLEServerCallbacks* pCallbacks);
     void                   startAdvertising();

--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -54,7 +54,7 @@ NimBLEService::NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLE
     m_pServer      = pServer;
     m_numHandles   = numHandles;
     m_pSvcDef      = nullptr;
-    m_removed      = false;
+    m_removed      = 0;
 
 } // NimBLEService
 
@@ -71,6 +71,10 @@ NimBLEService::~NimBLEService() {
         }
 
         delete(m_pSvcDef);
+    }
+
+    for(auto &it : m_chrVec) {
+        delete it;
     }
 }
 

--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -49,12 +49,29 @@ NimBLEService::NimBLEService(const char* uuid, uint16_t numHandles, NimBLEServer
  * @param [in] a pointer to the server instance that this service belongs to.
  */
 NimBLEService::NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLEServer* pServer) {
-    m_uuid       = uuid;
-    m_handle     = NULL_HANDLE;
-    m_pServer    = pServer;
-    m_numHandles = numHandles;
+    m_uuid         = uuid;
+    m_handle       = NULL_HANDLE;
+    m_pServer      = pServer;
+    m_numHandles   = numHandles;
+    m_pSvcDef      = nullptr;
+
 } // NimBLEService
 
+
+NimBLEService::~NimBLEService() {
+    if(m_pSvcDef != nullptr) {
+        if(m_pSvcDef->characteristics != nullptr) {
+            for(int i=0; m_pSvcDef->characteristics[i].uuid != NULL; ++i) {
+                if(m_pSvcDef->characteristics[i].descriptors) {
+                    delete(m_pSvcDef->characteristics[i].descriptors);
+                }
+            }
+            delete(m_pSvcDef->characteristics);
+        }
+
+        delete(m_pSvcDef);
+    }
+}
 
 /**
  * @brief Dump details of this BLE GATT service.
@@ -178,6 +195,7 @@ bool NimBLEService::start() {
 
     // end of services must indicate to api with type = 0
     svc[1].type = 0;
+    m_pSvcDef = svc;
 
     rc = ble_gatts_count_cfg((const ble_gatt_svc_def*)svc);
     if (rc != 0) {

--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -54,6 +54,7 @@ NimBLEService::NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLE
     m_pServer      = pServer;
     m_numHandles   = numHandles;
     m_pSvcDef      = nullptr;
+    m_removed      = false;
 
 } // NimBLEService
 
@@ -111,99 +112,101 @@ NimBLEUUID NimBLEService::getUUID() {
  * and registers it with the NimBLE stack.
  * @return bool success/failure .
  */
-
 bool NimBLEService::start() {
     NIMBLE_LOGD(LOG_TAG, ">> start(): Starting service: %s", toString().c_str());
     int rc = 0;
-    // Nimble requires an array of services to be sent to the api
-    // Since we are adding 1 at a time we create an array of 2 and set the type
-    // of the second service to 0 to indicate the end of the array.
-    ble_gatt_svc_def* svc = new ble_gatt_svc_def[2];
-    ble_gatt_chr_def* pChr_a = nullptr;
-    ble_gatt_dsc_def* pDsc_a = nullptr;
 
-    svc[0].type = BLE_GATT_SVC_TYPE_PRIMARY;
-    svc[0].uuid = &m_uuid.getNative()->u;
-    svc[0].includes = NULL;
+    if(m_pSvcDef == nullptr) {
+        // Nimble requires an array of services to be sent to the api
+        // Since we are adding 1 at a time we create an array of 2 and set the type
+        // of the second service to 0 to indicate the end of the array.
+        ble_gatt_svc_def* svc = new ble_gatt_svc_def[2];
+        ble_gatt_chr_def* pChr_a = nullptr;
+        ble_gatt_dsc_def* pDsc_a = nullptr;
 
-    size_t numChrs = m_chrVec.size();
+        svc[0].type = BLE_GATT_SVC_TYPE_PRIMARY;
+        svc[0].uuid = &m_uuid.getNative()->u;
+        svc[0].includes = NULL;
 
-    NIMBLE_LOGD(LOG_TAG,"Adding %d characteristics for service %s", numChrs, toString().c_str());
+        size_t numChrs = m_chrVec.size();
 
-    if(!numChrs){
-        svc[0].characteristics = NULL;
-    }else{
-        // Nimble requires the last characteristic to have it's uuid = 0 to indicate the end
-        // of the characteristics for the service. We create 1 extra and set it to null
-        // for this purpose.
-        pChr_a = new ble_gatt_chr_def[numChrs+1];
-        NimBLECharacteristic* pCharacteristic = *m_chrVec.begin();
+        NIMBLE_LOGD(LOG_TAG,"Adding %d characteristics for service %s", numChrs, toString().c_str());
 
-        for(uint8_t i=0; i < numChrs;) {
-            uint8_t numDscs = pCharacteristic->m_dscVec.size();
-            if(numDscs) {
-                // skip 2902 as it's automatically created by NimBLE
-                // if Indicate or Notify flags are set
-                if(((pCharacteristic->m_properties & BLE_GATT_CHR_F_INDICATE) ||
-                    (pCharacteristic->m_properties & BLE_GATT_CHR_F_NOTIFY))  &&
-                     pCharacteristic->getDescriptorByUUID("2902") != nullptr)
-                {
-                    numDscs--;
-                }
-            }
+        if(!numChrs){
+            svc[0].characteristics = NULL;
+        }else{
+            // Nimble requires the last characteristic to have it's uuid = 0 to indicate the end
+            // of the characteristics for the service. We create 1 extra and set it to null
+            // for this purpose.
+            pChr_a = new ble_gatt_chr_def[numChrs+1];
+            NimBLECharacteristic* pCharacteristic = *m_chrVec.begin();
 
-            if(!numDscs){
-                pChr_a[i].descriptors = NULL;
-            } else {
-                // Must have last descriptor uuid = 0 so we have to create 1 extra
-                //NIMBLE_LOGD(LOG_TAG, "Adding %d descriptors", numDscs);
-                pDsc_a = new ble_gatt_dsc_def[numDscs+1];
-                NimBLEDescriptor* pDescriptor = *pCharacteristic->m_dscVec.begin();
-                for(uint8_t d=0; d < numDscs;) {
-                    // skip 2902
-                    if(pDescriptor->m_uuid == NimBLEUUID(uint16_t(0x2902))) {
-                        //NIMBLE_LOGD(LOG_TAG, "Skipped 0x2902");
-                        pDescriptor = *(pCharacteristic->m_dscVec.begin()+d+1);
-                        continue;
+            for(uint8_t i=0; i < numChrs;) {
+                uint8_t numDscs = pCharacteristic->m_dscVec.size();
+                if(numDscs) {
+                    // skip 2902 as it's automatically created by NimBLE
+                    // if Indicate or Notify flags are set
+                    if(((pCharacteristic->m_properties & BLE_GATT_CHR_F_INDICATE) ||
+                        (pCharacteristic->m_properties & BLE_GATT_CHR_F_NOTIFY))  &&
+                         pCharacteristic->getDescriptorByUUID("2902") != nullptr)
+                    {
+                        numDscs--;
                     }
-                    pDsc_a[d].uuid = &pDescriptor->m_uuid.getNative()->u;
-                    pDsc_a[d].att_flags = pDescriptor->m_properties;
-                    pDsc_a[d].min_key_size = 0;
-                    pDsc_a[d].access_cb = NimBLEDescriptor::handleGapEvent;
-                    pDsc_a[d].arg = pDescriptor;
-                    d++;
-                    pDescriptor = *(pCharacteristic->m_dscVec.begin() + d);
                 }
 
-                pDsc_a[numDscs].uuid = NULL;
-                pChr_a[i].descriptors = pDsc_a;
+                if(!numDscs){
+                    pChr_a[i].descriptors = NULL;
+                } else {
+                    // Must have last descriptor uuid = 0 so we have to create 1 extra
+                    //NIMBLE_LOGD(LOG_TAG, "Adding %d descriptors", numDscs);
+                    pDsc_a = new ble_gatt_dsc_def[numDscs+1];
+                    NimBLEDescriptor* pDescriptor = *pCharacteristic->m_dscVec.begin();
+                    for(uint8_t d=0; d < numDscs;) {
+                        // skip 2902
+                        if(pDescriptor->m_uuid == NimBLEUUID(uint16_t(0x2902))) {
+                            //NIMBLE_LOGD(LOG_TAG, "Skipped 0x2902");
+                            pDescriptor = *(pCharacteristic->m_dscVec.begin()+d+1);
+                            continue;
+                        }
+                        pDsc_a[d].uuid = &pDescriptor->m_uuid.getNative()->u;
+                        pDsc_a[d].att_flags = pDescriptor->m_properties;
+                        pDsc_a[d].min_key_size = 0;
+                        pDsc_a[d].access_cb = NimBLEDescriptor::handleGapEvent;
+                        pDsc_a[d].arg = pDescriptor;
+                        d++;
+                        pDescriptor = *(pCharacteristic->m_dscVec.begin() + d);
+                    }
+
+                    pDsc_a[numDscs].uuid = NULL;
+                    pChr_a[i].descriptors = pDsc_a;
+                }
+
+                pChr_a[i].uuid = &pCharacteristic->m_uuid.getNative()->u;
+                pChr_a[i].access_cb = NimBLECharacteristic::handleGapEvent;
+                pChr_a[i].arg = pCharacteristic;
+                pChr_a[i].flags = pCharacteristic->m_properties;
+                pChr_a[i].min_key_size = 0;
+                pChr_a[i].val_handle = &pCharacteristic->m_handle;
+                i++;
+                pCharacteristic = *(m_chrVec.begin() + i);
             }
 
-            pChr_a[i].uuid = &pCharacteristic->m_uuid.getNative()->u;
-            pChr_a[i].access_cb = NimBLECharacteristic::handleGapEvent;
-            pChr_a[i].arg = pCharacteristic;
-            pChr_a[i].flags = pCharacteristic->m_properties;
-            pChr_a[i].min_key_size = 0;
-            pChr_a[i].val_handle = &pCharacteristic->m_handle;
-            i++;
-            pCharacteristic = *(m_chrVec.begin() + i);
+            pChr_a[numChrs].uuid = NULL;
+            svc[0].characteristics = pChr_a;
         }
 
-        pChr_a[numChrs].uuid = NULL;
-        svc[0].characteristics = pChr_a;
+        // end of services must indicate to api with type = 0
+        svc[1].type = 0;
+        m_pSvcDef = svc;
     }
 
-    // end of services must indicate to api with type = 0
-    svc[1].type = 0;
-    m_pSvcDef = svc;
-
-    rc = ble_gatts_count_cfg((const ble_gatt_svc_def*)svc);
+    rc = ble_gatts_count_cfg((const ble_gatt_svc_def*)m_pSvcDef);
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "ble_gatts_count_cfg failed, rc= %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
         return false;
     }
 
-    rc = ble_gatts_add_svcs((const ble_gatt_svc_def*)svc);
+    rc = ble_gatts_add_svcs((const ble_gatt_svc_def*)m_pSvcDef);
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "ble_gatts_add_svcs, rc= %d, %s", rc, NimBLEUtils::returnCodeToString(rc));
         return false;

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -35,7 +35,6 @@ class NimBLECharacteristic;
  */
 class NimBLEService {
 public:
-    ~NimBLEService();
     NimBLECharacteristic* createCharacteristic(const char* uuid,
                                               uint32_t properties =
                                               NIMBLE_PROPERTY::READ |
@@ -58,6 +57,7 @@ public:
 private:
     NimBLEService(const char* uuid, uint16_t numHandles, NimBLEServer* pServer);
     NimBLEService(const NimBLEUUID &uuid, uint16_t numHandles, NimBLEServer* pServer);
+    ~NimBLEService();
 
     friend class          NimBLEServer;
     friend class          NimBLEDevice;
@@ -67,7 +67,7 @@ private:
     NimBLEUUID            m_uuid;
     uint16_t              m_numHandles;
     ble_gatt_svc_def*     m_pSvcDef;
-    bool                  m_removed;
+    uint8_t               m_removed;
     std::vector<NimBLECharacteristic*> m_chrVec;
 
 }; // NimBLEService

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -67,6 +67,7 @@ private:
     NimBLEUUID            m_uuid;
     uint16_t              m_numHandles;
     ble_gatt_svc_def*     m_pSvcDef;
+    bool                  m_removed;
     std::vector<NimBLECharacteristic*> m_chrVec;
 
 }; // NimBLEService

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -35,6 +35,7 @@ class NimBLECharacteristic;
  */
 class NimBLEService {
 public:
+    ~NimBLEService();
     NimBLECharacteristic* createCharacteristic(const char* uuid,
                                               uint32_t properties =
                                               NIMBLE_PROPERTY::READ |
@@ -65,7 +66,7 @@ private:
     NimBLEServer*         m_pServer;
     NimBLEUUID            m_uuid;
     uint16_t              m_numHandles;
-
+    ble_gatt_svc_def*     m_pSvcDef;
     std::vector<NimBLECharacteristic*> m_chrVec;
 
 }; // NimBLEService


### PR DESCRIPTION
Allows adding/creating and removing services after starting server.

If NimBLEServer::removeService is called with the second parameter set to true, the service will also be deleted (see comments in file).

* Also implements adding/removing services from advertisements.