### PR TITLE
Add support for getting multiple services data from advertisments.

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -141,7 +141,7 @@ std::string NimBLEAdvertisedDevice::getServiceData(uint8_t index) {
  * @param [in] uuid The uuid of the service data requested.
  * @return The advertised service data or empty string if no data.
  */
-std::string NimBLEAdvertisedDevice::getServiceData(const NimBLEUUID &uuid) const{
+std::string NimBLEAdvertisedDevice::getServiceData(const NimBLEUUID &uuid) const {
     for(auto &it : m_serviceDataVec) {
         if(it.first == uuid) {
             return it.second;
@@ -193,7 +193,7 @@ NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID(uint8_t index) {
  * @brief Check advertised services for existance of the required UUID
  * @return Return true if service is advertised
  */
-bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid){
+bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid) const {
     for (int i = 0; i < m_serviceUUIDs.size(); i++) {
         if (m_serviceUUIDs[i].equals(uuid)) return true;
     }

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -31,7 +31,6 @@ static const char* LOG_TAG = "NimBLEAdvertisedDevice";
 NimBLEAdvertisedDevice::NimBLEAdvertisedDevice() {
     m_advType          = 0;
     m_appearance       = 0;
-    m_deviceType       = 0;
     m_manufacturerData = "";
     m_name             = "";
     m_rssi             = -9999;
@@ -130,6 +129,7 @@ NimBLEScan* NimBLEAdvertisedDevice::getScan() {
  */
 std::string NimBLEAdvertisedDevice::getServiceData(uint8_t index) {
     if(index > m_serviceDataVec.size()) {
+        NIMBLE_LOGW(LOG_TAG, "getServiceData: index out of range");
         return "";
     }
     return m_serviceDataVec[index].second;
@@ -147,7 +147,7 @@ std::string NimBLEAdvertisedDevice::getServiceData(const NimBLEUUID &uuid) const
             return it.second;
         }
     }
-
+        NIMBLE_LOGW(LOG_TAG, "getServiceData: uuid not found");
     return "";
 } //getServiceData
 
@@ -159,6 +159,7 @@ std::string NimBLEAdvertisedDevice::getServiceData(const NimBLEUUID &uuid) const
  */
 NimBLEUUID NimBLEAdvertisedDevice::getServiceDataUUID(uint8_t index) {
     if(!haveServiceData() || index > m_serviceDataVec.size()) {
+        NIMBLE_LOGW(LOG_TAG, "getServiceDataUUID: index out of range");
         return NimBLEUUID("");
     }
     return m_serviceDataVec[index].first;
@@ -181,6 +182,7 @@ size_t NimBLEAdvertisedDevice::getServiceDataCount() {
  */
 NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID(uint8_t index) {
     if(!haveServiceUUID() || index > m_serviceUUIDs.size()) {
+        NIMBLE_LOGW(LOG_TAG, "getServiceUUID: index out of range");
         return NimBLEUUID("");
     }
     return m_serviceUUIDs[index];
@@ -193,7 +195,6 @@ NimBLEUUID NimBLEAdvertisedDevice::getServiceUUID(uint8_t index) {
  */
 bool NimBLEAdvertisedDevice::isAdvertisingService(const NimBLEUUID &uuid){
     for (int i = 0; i < m_serviceUUIDs.size(); i++) {
-        NIMBLE_LOGI(LOG_TAG, "Comparing UUIDS: %s %s", m_serviceUUIDs[i].toString().c_str(), uuid.toString().c_str());
         if (m_serviceUUIDs[i].equals(uuid)) return true;
     }
     return false;
@@ -290,6 +291,12 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
 {
     m_payload = payload;
     m_payloadLength = length;
+
+#if CONFIG_LOG_DEFAULT_LEVEL > 3 || (ARDUINO_ARCH_ESP32 && CORE_DEBUG_LEVEL >= 4)
+    char* pHex = NimBLEUtils::buildHexData(nullptr, m_payload, m_payloadLength);
+    NIMBLE_LOGD(LOG_TAG,"payload: %s", pHex);
+    free(pHex);
+#endif
 
     if (fields->uuids16 != NULL) {
         for (int i = 0; i < fields->num_uuids16; i++) {
@@ -422,7 +429,6 @@ void NimBLEAdvertisedDevice::setAdvType(uint8_t advType) {
 void NimBLEAdvertisedDevice::setAppearance(uint16_t appearance) {
     m_appearance     = appearance;
     m_haveAppearance = true;
-    NIMBLE_LOGD(LOG_TAG,"- appearance: %d", m_appearance);
 } // setAppearance
 
 
@@ -433,10 +439,6 @@ void NimBLEAdvertisedDevice::setAppearance(uint16_t appearance) {
 void NimBLEAdvertisedDevice::setManufacturerData(std::string manufacturerData) {
     m_manufacturerData     = manufacturerData;
     m_haveManufacturerData = true;
-
-    char* pHex = NimBLEUtils::buildHexData(nullptr, (uint8_t*) m_manufacturerData.data(), (uint8_t) m_manufacturerData.length());
-    NIMBLE_LOGD(LOG_TAG,"- manufacturer data: %s", pHex);
-    free(pHex);
 } // setManufacturerData
 
 
@@ -447,7 +449,6 @@ void NimBLEAdvertisedDevice::setManufacturerData(std::string manufacturerData) {
 void NimBLEAdvertisedDevice::setName(std::string name) {
     m_name     = name;
     m_haveName = true;
-    NIMBLE_LOGD(LOG_TAG,"- setName(): name: %s", m_name.c_str());
 } // setName
 
 
@@ -458,7 +459,6 @@ void NimBLEAdvertisedDevice::setName(std::string name) {
 void NimBLEAdvertisedDevice::setRSSI(int rssi) {
     m_rssi     = rssi;
     m_haveRSSI = true;
-    NIMBLE_LOGD(LOG_TAG,"- setRSSI(): rssi: %d", m_rssi);
 } // setRSSI
 
 
@@ -485,7 +485,6 @@ void NimBLEAdvertisedDevice::setServiceUUID(NimBLEUUID serviceUUID) {
     }
     m_serviceUUIDs.push_back(serviceUUID);
     m_haveServiceUUID = true;
-    NIMBLE_LOGD(LOG_TAG,"- addServiceUUID(): serviceUUID: %s", serviceUUID.toString().c_str());
 } // setServiceUUID
 
 
@@ -513,7 +512,6 @@ void NimBLEAdvertisedDevice::setServiceData(NimBLEUUID uuid, std::string data) {
 void NimBLEAdvertisedDevice::setTXPower(int8_t txPower) {
     m_txPower     = txPower;
     m_haveTXPower = true;
-    NIMBLE_LOGD(LOG_TAG,"- txPower: %d", m_txPower);
 } // setTXPower
 
 

--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -285,10 +285,14 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
  *
  * https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile
  */
- void NimBLEAdvertisedDevice::parseAdvertisement(ble_hs_adv_fields *fields,
-                                                 uint8_t* payload,
-                                                 uint8_t length)
-{
+ void NimBLEAdvertisedDevice::parseAdvertisement(uint8_t* payload, uint8_t length) {
+    struct ble_hs_adv_fields fields;
+    int rc = ble_hs_adv_parse_fields(&fields, payload, length);
+    if (rc != 0) {
+        NIMBLE_LOGE(LOG_TAG, "Gap Event Parse ERROR.");
+        return;
+    }
+
     m_payload = payload;
     m_payloadLength = length;
 
@@ -298,35 +302,35 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
     free(pHex);
 #endif
 
-    if (fields->uuids16 != NULL) {
-        for (int i = 0; i < fields->num_uuids16; i++) {
-            setServiceUUID(NimBLEUUID(fields->uuids16[i].value));
+    if (fields.uuids16 != NULL) {
+        for (int i = 0; i < fields.num_uuids16; i++) {
+            setServiceUUID(NimBLEUUID(fields.uuids16[i].value));
         }
     }
 
-    if (fields->uuids32 != NULL) {
-        for (int i = 0; i < fields->num_uuids32; i++) {
-            setServiceUUID(NimBLEUUID(fields->uuids32[i].value));
+    if (fields.uuids32 != NULL) {
+        for (int i = 0; i < fields.num_uuids32; i++) {
+            setServiceUUID(NimBLEUUID(fields.uuids32[i].value));
         }
     }
 
-    if (fields->uuids128 != NULL) {
-        for (int i = 0; i < fields->num_uuids128; i++) {
-            setServiceUUID(NimBLEUUID(&fields->uuids128[i]));
+    if (fields.uuids128 != NULL) {
+        for (int i = 0; i < fields.num_uuids128; i++) {
+            setServiceUUID(NimBLEUUID(&fields.uuids128[i]));
         }
     }
 
-    if (fields->name != NULL) {
-        setName(std::string(reinterpret_cast<char*>(fields->name), fields->name_len));
+    if (fields.name != NULL) {
+        setName(std::string(reinterpret_cast<char*>(fields.name), fields.name_len));
     }
 
-    if (fields->tx_pwr_lvl_is_present) {
-        setTXPower(fields->tx_pwr_lvl);
+    if (fields.tx_pwr_lvl_is_present) {
+        setTXPower(fields.tx_pwr_lvl);
     }
 
-    if (fields->svc_data_uuid16 != NULL ||
-        fields->svc_data_uuid32 != NULL ||
-        fields->svc_data_uuid128 != NULL)
+    if (fields.svc_data_uuid16 != NULL ||
+        fields.svc_data_uuid32 != NULL ||
+        fields.svc_data_uuid128 != NULL)
     {
         ble_hs_adv_field *field;
         uint8_t *data = payload;
@@ -365,38 +369,38 @@ bool NimBLEAdvertisedDevice::haveTXPower() {
         }
     }
 
-    if (fields->appearance_is_present) {
-        setAppearance(fields->appearance);
+    if (fields.appearance_is_present) {
+        setAppearance(fields.appearance);
     }
 
-    if (fields->mfg_data != NULL) {
-        setManufacturerData(std::string(reinterpret_cast<char*>(fields->mfg_data), fields->mfg_data_len));
+    if (fields.mfg_data != NULL) {
+        setManufacturerData(std::string(reinterpret_cast<char*>(fields.mfg_data), fields.mfg_data_len));
     }
 
 /* TODO: create storage and fucntions for these parameters
-    if (fields->public_tgt_addr != NULL) {
+    if (fields.public_tgt_addr != NULL) {
         NIMBLE_LOGD(LOG_TAG, "    public_tgt_addr=");
-        u8p = fields->public_tgt_addr;
-        for (i = 0; i < fields->num_public_tgt_addrs; i++) {
+        u8p = fields.public_tgt_addr;
+        for (i = 0; i < fields.num_public_tgt_addrs; i++) {
             NIMBLE_LOGD(LOG_TAG, "public_tgt_addr=%s ", addr_str(u8p));
             u8p += BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN;
         }
         NIMBLE_LOGD(LOG_TAG, "\n");
     }
 
-    if (fields->slave_itvl_range != NULL) {
+    if (fields.slave_itvl_range != NULL) {
         NIMBLE_LOGD(LOG_TAG, "    slave_itvl_range=");
-        print_bytes(fields->slave_itvl_range, BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
+        print_bytes(fields.slave_itvl_range, BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
         NIMBLE_LOGD(LOG_TAG, "\n");
     }
 
-    if (fields->adv_itvl_is_present) {
-        NIMBLE_LOGD(LOG_TAG, "    adv_itvl=0x%04x\n", fields->adv_itvl);
+    if (fields.adv_itvl_is_present) {
+        NIMBLE_LOGD(LOG_TAG, "    adv_itvl=0x%04x\n", fields.adv_itvl);
     }
 
-    if (fields->uri != NULL) {
+    if (fields.uri != NULL) {
         NIMBLE_LOGD(LOG_TAG, "    uri=");
-        print_bytes(fields->uri, fields->uri_len);
+        print_bytes(fields.uri, fields.uri_len);
         NIMBLE_LOGD(LOG_TAG, "\n");
     }
 */

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -46,16 +46,16 @@ public:
     uint16_t        getAppearance();
     std::string     getManufacturerData();
 
-/**
- * @brief A template to convert the service data to <type\>.
- * @tparam T The type to convert the data to.
- * @param [in] skipSizeCheck If true it will skip checking if the data size is less than <tt>sizeof(<type\>)</tt>.
- * @return The data converted to <type\> or NULL if skipSizeCheck is false and the data is
- * less than <tt>sizeof(<type\>)</tt>.
- * @details <b>Use:</b> <tt>getManufacturerData<type>(skipSizeCheck);</tt>
- */
+    /**
+     * @brief A template to convert the service data to <type\>.
+     * @tparam T The type to convert the data to.
+     * @param [in] skipSizeCheck If true it will skip checking if the data size is less than <tt>sizeof(<type\>)</tt>.
+     * @return The data converted to <type\> or NULL if skipSizeCheck is false and the data is
+     * less than <tt>sizeof(<type\>)</tt>.
+     * @details <b>Use:</b> <tt>getManufacturerData<type>(skipSizeCheck);</tt>
+     */
     template<typename T>
-    T               getManufacturerData(bool skipSizeCheck = false) {
+    T       getManufacturerData(bool skipSizeCheck = false) {
         std::string data = getManufacturerData();
         if(!skipSizeCheck && data.size() < sizeof(T)) return T();
         const char *pData = data.data();
@@ -65,26 +65,47 @@ public:
     std::string     getName();
     int             getRSSI();
     NimBLEScan*     getScan();
-    std::string     getServiceData();
+    size_t          getServiceDataCount();
+    std::string     getServiceData(uint8_t index = 0);
+    std::string     getServiceData(const NimBLEUUID &uuid) const;
 
-/**
- * @brief A template to convert the service data to <tt><type\></tt>.
- * @tparam T The type to convert the data to.
- * @param [in] skipSizeCheck If true it will skip checking if the data size is less than <tt>sizeof(<type\>)</tt>.
- * @return The data converted to <type\> or NULL if skipSizeCheck is false and the data is
- * less than <tt>sizeof(<type\>)</tt>.
- * @details <b>Use:</b> <tt>getServiceData<type>(skipSizeCheck);</tt>
- */
+    /**
+     * @brief A template to convert the service data to <tt><type\></tt>.
+     * @tparam T The type to convert the data to.
+     * @param [in] index The vector index of the service data requested.
+     * @param [in] skipSizeCheck If true it will skip checking if the data size is less than <tt>sizeof(<type\>)</tt>.
+     * @return The data converted to <type\> or NULL if skipSizeCheck is false and the data is
+     * less than <tt>sizeof(<type\>)</tt>.
+     * @details <b>Use:</b> <tt>getServiceData<type>(skipSizeCheck);</tt>
+     */
     template<typename T>
-    T               getServiceData(bool skipSizeCheck = false) {
-        std::string data = getServiceData();
+    T       getServiceData(uint8_t index = 0, bool skipSizeCheck = false) {
+        std::string data = getServiceData(index);
         if(!skipSizeCheck && data.size() < sizeof(T)) return T();
         const char *pData = data.data();
         return *((T *)pData);
     }
 
-    NimBLEUUID      getServiceDataUUID();
-    NimBLEUUID      getServiceUUID();
+    /**
+     * @brief A template to convert the service data to <tt><type\></tt>.
+     * @tparam T The type to convert the data to.
+     * @param [in] uuid The uuid of the service data requested.
+     * @param [in] skipSizeCheck If true it will skip checking if the data size is less than <tt>sizeof(<type\>)</tt>.
+     * @return The data converted to <type\> or NULL if skipSizeCheck is false and the data is
+     * less than <tt>sizeof(<type\>)</tt>.
+     * @details <b>Use:</b> <tt>getServiceData<type>(skipSizeCheck);</tt>
+     */
+    template<typename T>
+    T       getServiceData(const NimBLEUUID &uuid, bool skipSizeCheck = false) {
+        std::string data = getServiceData(uuid);
+        if(!skipSizeCheck && data.size() < sizeof(T)) return T();
+        const char *pData = data.data();
+        return *((T *)pData);
+    }
+
+    NimBLEUUID      getServiceDataUUID(uint8_t index = 0);
+    NimBLEUUID      getServiceUUID(uint8_t index = 0);
+    size_t          getServiceUUIDCount();
     int8_t          getTXPower();
     uint8_t*        getPayload();
     size_t          getPayloadLength();
@@ -107,17 +128,14 @@ public:
 private:
     friend class NimBLEScan;
 
-    void parseAdvertisement(ble_hs_adv_fields *fields);
+    void parseAdvertisement(ble_hs_adv_fields *fields, uint8_t* payload, uint8_t length);
     void setAddress(NimBLEAddress address);
     void setAdvType(uint8_t advType);
-    void setAdvertisementResult(uint8_t* payload, uint8_t length);
     void setAppearance(uint16_t appearance);
     void setManufacturerData(std::string manufacturerData);
     void setName(std::string name);
     void setRSSI(int rssi);
-    void setScan(NimBLEScan* pScan);
-    void setServiceData(std::string data);
-    void setServiceDataUUID(NimBLEUUID uuid);
+    void setServiceData(NimBLEUUID serviceUUID, std::string data);
     void setServiceUUID(const char* serviceUUID);
     void setServiceUUID(NimBLEUUID serviceUUID);
     void setTXPower(int8_t txPower);
@@ -137,11 +155,8 @@ private:
     int             m_deviceType;
     std::string     m_manufacturerData;
     std::string     m_name;
-    NimBLEScan*     m_pScan;
     int             m_rssi;
     int8_t          m_txPower;
-    std::string     m_serviceData;
-    NimBLEUUID      m_serviceDataUUID;
     uint8_t*        m_payload;
     size_t          m_payloadLength;
     uint8_t         m_addressType;
@@ -149,6 +164,7 @@ private:
     bool            m_callbackSent;
 
     std::vector<NimBLEUUID> m_serviceUUIDs;
+    std::vector<std::pair<NimBLEUUID, std::string>>m_serviceDataVec;
 };
 
 /**
@@ -167,7 +183,6 @@ public:
      * As we are scanning, we will find new devices.  When found, this call back is invoked with a reference to the
      * device that was found.  During any individual scan, a device will only be detected one time.
      */
-    //virtual void onResult(NimBLEAdvertisedDevice advertisedDevice) = 0;
     virtual void onResult(NimBLEAdvertisedDevice* advertisedDevice) = 0;
 };
 

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -128,7 +128,7 @@ public:
 private:
     friend class NimBLEScan;
 
-    void parseAdvertisement(ble_hs_adv_fields *fields, uint8_t* payload, uint8_t length);
+    void parseAdvertisement(uint8_t* payload, uint8_t length);
     void setAddress(NimBLEAddress address);
     void setAdvType(uint8_t advType);
     void setAppearance(uint16_t appearance);

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -152,7 +152,6 @@ private:
     NimBLEAddress   m_address = NimBLEAddress("");
     uint8_t         m_advType;
     uint16_t        m_appearance;
-    int             m_deviceType;
     std::string     m_manufacturerData;
     std::string     m_name;
     int             m_rssi;

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -114,7 +114,7 @@ public:
     void            setAddressType(uint8_t type);
 
 
-    bool        isAdvertisingService(const NimBLEUUID &uuid);
+    bool        isAdvertisingService(const NimBLEUUID &uuid) const;
     bool        haveAppearance();
     bool        haveManufacturerData();
     bool        haveName();

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -52,21 +52,12 @@ NimBLEScan::NimBLEScan() {
 /*STATIC*/int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
 
     NimBLEScan* pScan = (NimBLEScan*)arg;
-    struct ble_hs_adv_fields fields;
-    int rc = 0;
 
     switch(event->type) {
 
         case BLE_GAP_EVENT_DISC: {
             if(pScan->m_stopped) {
                 NIMBLE_LOGE(LOG_TAG, "Scan stop called, ignoring results.");
-                return 0;
-            }
-
-            rc = ble_hs_adv_parse_fields(&fields, event->disc.data,
-                                     event->disc.length_data);
-            if (rc != 0) {
-                NIMBLE_LOGE(LOG_TAG, "Gap Event Parse ERROR.");
                 return 0;
             }
 
@@ -103,7 +94,7 @@ NimBLEScan::NimBLEScan() {
             }
             advertisedDevice->setRSSI(event->disc.rssi);
             if(event->disc.length_data > 0) {
-                advertisedDevice->parseAdvertisement(&fields, event->disc.data, event->disc.length_data);
+                advertisedDevice->parseAdvertisement(event->disc.data, event->disc.length_data);
             }
             advertisedDevice->m_timestamp = time(nullptr);
 

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -102,9 +102,9 @@ NimBLEScan::NimBLEScan() {
                 NIMBLE_LOGI(LOG_TAG, "UPDATING PREVIOUSLY FOUND DEVICE: %s", advertisedAddress.toString().c_str());
             }
             advertisedDevice->setRSSI(event->disc.rssi);
-            advertisedDevice->parseAdvertisement(&fields);
-            advertisedDevice->setScan(pScan);
-            advertisedDevice->setAdvertisementResult(event->disc.data, event->disc.length_data);
+            if(event->disc.length_data > 0) {
+                advertisedDevice->parseAdvertisement(&fields, event->disc.data, event->disc.length_data);
+            }
             advertisedDevice->m_timestamp = time(nullptr);
 
             if (pScan->m_pAdvertisedDeviceCallbacks) {


### PR DESCRIPTION
Adds new methods for getting advertised service data and UUIDS.
- getServiceData(index), gets the service data by index value.
- getServiceData(NimBLEUUID), gets the service data by UUID.
- getServiceDataCount(), gets the number of services with data advertised.
- getServiceDataUUID(index), gets the UUID of the service advertising data by index value.

Templates added for getServiceData(index) and getServiceData(NimBLEUUID) to be able to specify 
the data type returned by these methods.
  Example:
      `getServiceData<uint32_t>(NimBLEUUID("ABCD"));`

Also added:
- getServiceUUID(index), gets the advertised service UUID by index value.
- getServiceUUIDCount(), gets the number of advertised services.