### PR TITLE
Add clearAll parameter to deinit()

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -539,6 +539,8 @@ void NimBLEDevice::stopAdvertising() {
 
 /**
  * @brief Shutdown the NimBLE stack/controller.
+ * @param [in] clearAll If true, deletes all server/advertising/scan/client objects after deinitializing.
+ * @note If clearAll is true when called, any references to the created objects become invalid.
  */
 /* STATIC */ void NimBLEDevice::deinit(bool clearAll) {
     int ret = nimble_port_stop();

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -540,7 +540,7 @@ void NimBLEDevice::stopAdvertising() {
 /**
  * @brief Shutdown the NimBLE stack/controller.
  */
-/* STATIC */ void NimBLEDevice::deinit() {
+/* STATIC */ void NimBLEDevice::deinit(bool clearAll) {
     int ret = nimble_port_stop();
     if (ret == 0) {
         nimble_port_deinit();
@@ -552,6 +552,42 @@ void NimBLEDevice::stopAdvertising() {
 
         initialized = false;
         m_synced = false;
+
+        if(clearAll) {
+#if defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
+            if(NimBLEDevice::m_pServer != nullptr) {
+                delete NimBLEDevice::m_pServer;
+                NimBLEDevice::m_pServer = nullptr;
+            }
+#endif
+
+#if defined(CONFIG_BT_NIMBLE_ROLE_BROADCASTER)
+            if(NimBLEDevice::m_bleAdvertising != nullptr) {
+                delete NimBLEDevice::m_bleAdvertising;
+                NimBLEDevice::m_bleAdvertising = nullptr;
+            }
+#endif
+
+#if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
+            if(NimBLEDevice::m_pScan != nullptr) {
+                delete NimBLEDevice::m_pScan;
+                NimBLEDevice::m_pScan= nullptr;
+            }
+#endif
+
+#if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+            for(auto &it : m_cList) {
+                deleteClient(it);
+                m_cList.clear();
+            }
+#endif
+
+            m_ignoreList.clear();
+
+            if(m_securityCallbacks != nullptr) {
+                delete m_securityCallbacks;
+            }
+        }
     }
 } // deinit
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -91,7 +91,7 @@ extern "C" void ble_store_config_init(void);
 class NimBLEDevice {
 public:
     static void             init(const std::string &deviceName);
-    static void             deinit();
+    static void             deinit(bool clearAll = false);
     static bool             getInitialized();
     static NimBLEAddress    getAddress();
     static std::string      toString();

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -45,6 +45,13 @@ NimBLEScan::NimBLEScan() {
 
 
 /**
+ * @brief Scan destructor, release any allocated resources.
+ */
+NimBLEScan::~NimBLEScan() {
+     clearResults();
+}
+
+/**
  * @brief Handle GAP events related to scans.
  * @param [in] event The event type for this event.
  * @param [in] param Parameter data for this event.

--- a/src/NimBLEScan.h
+++ b/src/NimBLEScan.h
@@ -76,8 +76,10 @@ public:
 
 
 private:
-    NimBLEScan();
     friend class NimBLEDevice;
+
+    NimBLEScan();
+    ~NimBLEScan();
     static int          handleGapEvent(ble_gap_event*  event, void* arg);
     void                onHostReset();
 

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -42,6 +42,7 @@ NimBLEServer::NimBLEServer() {
     m_gattsStarted          = false;
     m_advertiseOnDisconnect = true;
     m_svcChanged            = false;
+    m_deleteCallbacks       = true;
 } // NimBLEServer
 
 
@@ -51,6 +52,10 @@ NimBLEServer::NimBLEServer() {
 NimBLEServer::~NimBLEServer() {
     for(auto &it : m_svcVec) {
         delete it;
+    }
+
+    if(m_deleteCallbacks && m_pServerCallbacks != &defaultCallbacks) {
+        delete m_pServerCallbacks;
     }
 }
 
@@ -469,10 +474,12 @@ size_t NimBLEServer::getConnectedCount() {
  * events are detected.
  *
  * @param [in] pCallbacks The callbacks to be invoked.
+ * @param [in] deleteCallbacks if true callback class will be deleted when server is destructed.
  */
-void NimBLEServer::setCallbacks(NimBLEServerCallbacks* pCallbacks) {
+void NimBLEServer::setCallbacks(NimBLEServerCallbacks* pCallbacks, bool deleteCallbacks) {
     if (pCallbacks != nullptr){
         m_pServerCallbacks = pCallbacks;
+        m_deleteCallbacks = deleteCallbacks;
     } else {
         m_pServerCallbacks = &defaultCallbacks;
     }

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -44,7 +44,8 @@ public:
     void                   removeService(NimBLEService* service, bool deleteSvc = false);
     void                   addService(NimBLEService* service);
     NimBLEAdvertising*     getAdvertising();
-    void                   setCallbacks(NimBLEServerCallbacks* pCallbacks);
+    void                   setCallbacks(NimBLEServerCallbacks* pCallbacks,
+                                        bool deleteCallbacks = true);
     void                   startAdvertising();
     void                   stopAdvertising();
     void                   start();
@@ -70,6 +71,7 @@ private:
     bool                   m_advertiseOnDisconnect;
     bool                   m_svcChanged;
     NimBLEServerCallbacks* m_pServerCallbacks;
+    bool                   m_deleteCallbacks;
     std::vector<uint16_t>  m_connectedPeersVec;
 
 //    uint16_t               m_svcChgChrHdl; // Future use


### PR DESCRIPTION
Adds the ability to clear all resources consumed during BLE operation when deinitializing and shutting down BLE.
Useful when BLE is used intermittently or in a task that initializes, performs operations then deinitializes.

By setting the clearAll parameter to true all created BLE objects will be deleted, freeing the memory for other tasks.

Warning: This will invalidate any pointers that may be referencing the deleted objects.

* Add bool deleteCallbacks parameter to NimBLEServer::setCallbacks, if true (default) will delete the callback class when server is destructed.

* Delete scan results when scan is destructed.