### PR TITLE
Fix some issues on ESP32-S3

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -247,7 +247,6 @@ std::vector<uint8_t> NimBLECharacteristic::getValue(time_t *timestamp) {
 
 /**
  * @brief Retrieve the current value of the characteristic, copy to designated buffer to avoid excessive heap allocation
- * @return A std::string containing the current characteristic value.
  */
 void NimBLECharacteristic::getValue(uint8_t *bufOut, size_t *lenOut, size_t bufSize, time_t *timestamp) {
     if (bufOut == nullptr || lenOut == nullptr) return;

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -103,8 +103,9 @@ public:
     NimBLEDescriptor* getDescriptorByHandle(uint16_t handle);
     void              removeDescriptor(NimBLEDescriptor *pDescriptor, bool deleteDsc = false);
 
-    std::string       getValue(time_t *timestamp = nullptr);
-    size_t            getDataLength();
+    std::vector<uint8_t>      getValue(time_t *timestamp = nullptr);
+    void                      getValue(uint8_t *bufOut, size_t *lenOut, size_t bufSize, time_t *timestamp = nullptr);
+    size_t                    getDataLength();
     /**
      * @brief A template to convert the characteristic data to <type\>.
      * @tparam T The type to convert the data to.
@@ -151,7 +152,7 @@ private:
     uint16_t                       m_properties;
     NimBLECharacteristicCallbacks* m_pCallbacks;
     NimBLEService*                 m_pService;
-    std::string                    m_value;
+    std::vector<uint8_t>           m_value;
     std::vector<NimBLEDescriptor*> m_dscVec;
     portMUX_TYPE                   m_valMux;
     time_t                         m_timestamp;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -769,7 +769,7 @@ NimBLEAddress NimBLEDevice::getWhiteListAddress(size_t index) {
         esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 
         esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#if  defined (CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
         bt_cfg.bluetooth_mode = ESP_BT_MODE_BLE;
 #else
         bt_cfg.mode = ESP_BT_MODE_BLE;


### PR DESCRIPTION
Hi @h2zero 

Here's a quick fix to get this library working on ESP32-S3. I suspect there will be more place to fix but so far it (should) just suits my application.

Meanwhile I've also found out that the way you handle data for each characteristic may get in undefined behaviour on ESP32-S3 when the received data is longer than 16 bytes. This is probably caused by Short String Optimisation. But I haven't really looked into it yet. Instead, I used vector instead, as it's more suitable for handling both binary and string data anyway.

To be more specific your master branch, if I type in a few "aaaaa..." and log the buffer via `ESP_LOG_HEXDUMP()` at here: https://github.com/h2zero/esp-nimble-cpp/blob/master/src/NimBLECharacteristic.cpp#L305 and then log the `characteristic->getValue().data()` in the callback class:

It should be always`61 61 61 61 61 61 ...`,   but it shows some garbage data like `14 00 ce 3f 14 00 ce 3f `:

```
W (92228) nimble_cpp: 0x3fca269b   61 61 61 61 61 61 61 61  61 61 61 61 61 61 61 61  |aaaaaaaaaaaaaaaa|
W (92228) cb_class: 0x3fcea328   14 00 ce 3f 14 00 ce 3f  61 61 61 61 61 61 61 61  |...?...?aaaaaaaa|
```

But if the data sent in is short enough, it has the right result:

```
W (36878) nimble_cpp: 0x3fca269b   61 61                                             |aa|
W (36879) cb_class: 0x3fca4848   61 61                                             |aa|
```

So, anyway, like I said before, I decided to scrap the `std::string` and use `vector` instead. I've also called `reserve()` at constructor so that it should somewhat reduce the reallocation and heap fragmentation.

Regards,
Jackson 
