### PR TITLE
Add method to send notifications/indications with custom values

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -399,6 +399,7 @@ void NimBLECharacteristic::indicate() {
     NIMBLE_LOGD(LOG_TAG, "<< indicate");
 } // indicate
 
+
 /**
  * @brief Send a notification.\n
  * A notification is a transmission of up to the first 20 bytes of the characteristic value.\n
@@ -406,8 +407,18 @@ void NimBLECharacteristic::indicate() {
  * @param[in] is_notification if true sends a notification, false sends an indication.
  */
 void NimBLECharacteristic::notify(bool is_notification) {
-    NIMBLE_LOGD(LOG_TAG, ">> notify: length: %d", getDataLength());
+    notify(getValue(), is_notification);
+}
 
+/**
+ * @brief Send a notification.\n
+ * A notification is a transmission of up to the first 20 bytes of the characteristic value.\n
+ * A notification will not block; it is a fire and forget.
+ * @param[in] is_notification if true sends a notification, false sends an indication.
+ */
+void NimBLECharacteristic::notify(std::string value, bool is_notification) {
+    size_t length = value.length();
+    NIMBLE_LOGD(LOG_TAG, ">> notify: length: %d", length);
 
     if(!(m_properties & NIMBLE_PROPERTY::NOTIFY) &&
        !(m_properties & NIMBLE_PROPERTY::INDICATE))
@@ -423,9 +434,7 @@ void NimBLECharacteristic::notify(bool is_notification) {
     }
 
     m_pCallbacks->onNotify(this);
-
-    std::string value = getValue();
-    size_t length = value.length();
+    
     bool reqSec = (m_properties & BLE_GATT_CHR_F_READ_AUTHEN) ||
                   (m_properties & BLE_GATT_CHR_F_READ_AUTHOR) ||
                   (m_properties & BLE_GATT_CHR_F_READ_ENC);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -82,6 +82,8 @@ public:
 
     void              indicate();
     void              notify(bool is_notification = true);
+    void              notify(std::string value, bool is_notification = true);
+
     size_t            getSubscribedCount();
 
     NimBLEDescriptor* createDescriptor(const char* uuid,


### PR DESCRIPTION
This is useful when not treating the characteristic as a normal resource and instead using it to send a stream of data.