### PR TITLE
[Breaking] Remove deprecated functions/response parameter from un/sub

### DIFF
--- a/docs/Improvements_and_updates.md
+++ b/docs/Improvements_and_updates.md
@@ -96,12 +96,13 @@ struct my_struct{
 ```
 <br/>
 
-`NimBLERemoteCharacteristic::registerForNotify`
-Has been **deprecated** as now the internally stored characteristic value is updated when notification/indication is received.
+`NimBLERemoteCharacteristic::registerForNotify`  
+Has been removed.
 
-`NimBLERemoteCharacteristic::subscribe` and `NimBLERemoteCharacteristic::unsubscribe` have been implemented to replace it.
-A callback is no longer required to get the most recent value unless timing is important. Instead, the application can call `NimBLERemoteCharacteristic::getValue` to get the last updated value any time.  
-<br/>
+`NimBLERemoteCharacteristic::subscribe` and `NimBLERemoteCharacteristic::unsubscribe` have been implemented to replace it.  
+
+The internally stored characteristic value is now updated when notification/indication is recieved. Making a callback no longer required to get the most recent value unless timing is important. Instead, the application can call `NimBLERemoteCharacteristic::getValue` to get the most recent value any time.  
+<br/>  
 
 The `notify_callback` function is now defined as a `std::function` to take advantage of using `std::bind` to specify a class member function for the callback.
 

--- a/docs/Migration_guide.md
+++ b/docs/Migration_guide.md
@@ -272,16 +272,16 @@ Also now returns a pointer to `std::vector` instead of `std::map`.
  There have been a few changes to the methods in this class:
 
 > `BLERemoteCharacteristic::writeValue` (`NimBLERemoteCharacteristic::writeValue`)
-> `BLERemoteCharacteristic::registerForNotify` (`NimBLERemoteCharacteristic::registerForNotify`)
 
-Now return true or false to indicate success or failure so you can choose to disconnect or try again.
+Now returns true or false to indicate success or failure so you can choose to disconnect or try again.  
 <br/>
 
-> `BLERemoteCharacteristic::registerForNotify` (`NimBLERemoteCharacteristic::registerForNotify`)
+> `BLERemoteCharacteristic::registerForNotify`
 
-Is now **deprecated**.
-> `NimBLERemoteCharacteristic::subscribe`
-> `NimBLERemoteCharacteristic::unsubscribe`
+Has been removed.
+
+> `NimBLERemoteCharacteristic::subscribe`  
+> `NimBLERemoteCharacteristic::unsubscribe`  
 
 Are the new methods added to replace it.
 <br/>

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -440,46 +440,7 @@ NimBLEAttValue NimBLERemoteCharacteristic::getValue(time_t *timestamp) {
     }
 
     return m_value;
-}
-
-
-/**
- * @brief Read an unsigned 16 bit value
- * @return The unsigned 16 bit value.
- * @deprecated Use readValue<uint16_t>().
- */
-uint16_t NimBLERemoteCharacteristic::readUInt16() {
-    return readValue<uint16_t>();
-} // readUInt16
-
-
-/**
- * @brief Read an unsigned 32 bit value.
- * @return the unsigned 32 bit value.
- * @deprecated Use readValue<uint32_t>().
- */
-uint32_t NimBLERemoteCharacteristic::readUInt32() {
-    return readValue<uint32_t>();
-} // readUInt32
-
-
-/**
- * @brief Read a byte value
- * @return The value as a byte
- * @deprecated Use readValue<uint8_t>().
- */
-uint8_t NimBLERemoteCharacteristic::readUInt8() {
-    return readValue<uint8_t>();
-} // readUInt8
-
-
-/**
- * @brief Read a float value.
- * @return the float value.
- */
-float NimBLERemoteCharacteristic::readFloat() {
-	return readValue<float>();
-} // readFloat
+} // getValue
 
 
 /**
@@ -592,7 +553,7 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
     xTaskNotifyGive(pTaskData->task);
 
     return rc;
-}
+} // onReadCB
 
 
 /**
@@ -603,7 +564,7 @@ int NimBLERemoteCharacteristic::onReadCB(uint16_t conn_handle,
  * If NULL is provided then no callback is performed.
  * @return false if writing to the descriptor failed.
  */
-bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyCallback, bool response) {
+bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyCallback) {
     NIMBLE_LOGD(LOG_TAG, ">> setNotify(): %s, %02x", toString().c_str(), val);
 
     m_notifyCallback = notifyCallback;
@@ -615,9 +576,7 @@ bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyC
     }
 
     NIMBLE_LOGD(LOG_TAG, "<< setNotify()");
-
-    response = true; // Always write with response as per Bluetooth core specification.
-    return desc->writeValue((uint8_t *)&val, 2, response);
+    return desc->writeValue((uint8_t *)&val, 2, true);
 } // setNotify
 
 
@@ -629,11 +588,11 @@ bool NimBLERemoteCharacteristic::setNotify(uint16_t val, notify_callback notifyC
  * If NULL is provided then no callback is performed.
  * @return false if writing to the descriptor failed.
  */
-bool NimBLERemoteCharacteristic::subscribe(bool notifications, notify_callback notifyCallback, bool response) {
+bool NimBLERemoteCharacteristic::subscribe(bool notifications, notify_callback notifyCallback) {
     if(notifications) {
-        return setNotify(0x01, notifyCallback, response);
+        return setNotify(0x01, notifyCallback);
     } else {
-        return setNotify(0x02, notifyCallback, response);
+        return setNotify(0x02, notifyCallback);
     }
 } // subscribe
 
@@ -643,29 +602,9 @@ bool NimBLERemoteCharacteristic::subscribe(bool notifications, notify_callback n
  * @param [in] response bool if true, require a write response from the descriptor write operation.
  * @return false if writing to the descriptor failed.
  */
-bool NimBLERemoteCharacteristic::unsubscribe(bool response) {
-    return setNotify(0x00, nullptr, response);
+bool NimBLERemoteCharacteristic::unsubscribe() {
+    return setNotify(0x00, nullptr);
 } // unsubscribe
-
-
- /**
- * @brief backward-compatibility method for subscribe/unsubscribe notifications/indications
- * @param [in] notifyCallback A callback to be invoked for a notification. If NULL is provided then we
- * will unregister for notifications.
- * @param [in] notifications If true, register for notifications, false register for indications.
- * @param [in] response If true, require a write response from the descriptor write operation.
- * @return true if successful.
- * @deprecated Use subscribe() / unsubscribe() instead.
- */
-bool NimBLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, bool notifications, bool response) {
-    bool success;
-    if(notifyCallback != nullptr) {
-        success = subscribe(notifications, notifyCallback, response);
-    } else {
-        success = unsubscribe(response);
-    }
-    return success;
-} // registerForNotify
 
 
 /**

--- a/src/NimBLERemoteCharacteristic.h
+++ b/src/NimBLERemoteCharacteristic.h
@@ -64,21 +64,10 @@ public:
     NimBLEAttValue                                 readValue(time_t *timestamp = nullptr);
     std::string                                    toString();
     NimBLERemoteService*                           getRemoteService();
-
-    uint8_t                                        readUInt8()  __attribute__ ((deprecated("Use template readValue<uint8_t>()")));
-    uint16_t                                       readUInt16() __attribute__ ((deprecated("Use template readValue<uint16_t>()")));
-    uint32_t                                       readUInt32() __attribute__ ((deprecated("Use template readValue<uint32_t>()")));
-    float                                          readFloat()  __attribute__ ((deprecated("Use template readValue<float>()")));
     NimBLEAttValue                                 getValue(time_t *timestamp = nullptr);
-
     bool                                           subscribe(bool notifications = true,
-                                                             notify_callback notifyCallback = nullptr,
-                                                             bool response = true);
-    bool                                           unsubscribe(bool response = true);
-    bool                                           registerForNotify(notify_callback notifyCallback,
-                                                                     bool notifications = true,
-                                                                     bool response = true)
-                                                                     __attribute__ ((deprecated("Use subscribe()/unsubscribe()")));
+                                                             notify_callback notifyCallback = nullptr);
+    bool                                           unsubscribe();
     bool                                           writeValue(const uint8_t* data,
                                                               size_t length,
                                                               bool response = false);
@@ -160,7 +149,7 @@ private:
     friend class      NimBLERemoteDescriptor;
 
     // Private member functions
-    bool              setNotify(uint16_t val, notify_callback notifyCallback = nullptr, bool response = true);
+    bool              setNotify(uint16_t val, notify_callback notifyCallback = nullptr);
     bool              retrieveDescriptors(const NimBLEUUID *uuid_filter = nullptr);
     static int        onReadCB(uint16_t conn_handle, const struct ble_gatt_error *error,
                                struct ble_gatt_attr *attr, void *arg);

--- a/src/NimBLERemoteDescriptor.cpp
+++ b/src/NimBLERemoteDescriptor.cpp
@@ -81,36 +81,6 @@ NimBLEUUID NimBLERemoteDescriptor::getUUID() {
 
 
 /**
- * @brief Read a byte value
- * @return The value as a byte
- * @deprecated Use readValue<uint8_t>().
- */
-uint8_t NimBLERemoteDescriptor::readUInt8() {
-    return readValue<uint8_t>();
-} // readUInt8
-
-
-/**
- * @brief Read an unsigned 16 bit value
- * @return The unsigned 16 bit value.
- * @deprecated Use readValue<uint16_t>().
- */
-uint16_t NimBLERemoteDescriptor::readUInt16() {
-    return readValue<uint16_t>();
-} // readUInt16
-
-
-/**
- * @brief Read an unsigned 32 bit value.
- * @return the unsigned 32 bit value.
- * @deprecated Use readValue<uint32_t>().
- */
-uint32_t NimBLERemoteDescriptor::readUInt32() {
-    return readValue<uint32_t>();
-} // readUInt32
-
-
-/**
  * @brief Read the value of the remote descriptor.
  * @return The value of the remote descriptor.
  */

--- a/src/NimBLERemoteDescriptor.h
+++ b/src/NimBLERemoteDescriptor.h
@@ -30,10 +30,6 @@ public:
     NimBLERemoteCharacteristic* getRemoteCharacteristic();
     NimBLEUUID                  getUUID();
     NimBLEAttValue              readValue();
-
-    uint8_t                     readUInt8()  __attribute__ ((deprecated("Use template readValue<uint8_t>()")));
-    uint16_t                    readUInt16() __attribute__ ((deprecated("Use template readValue<uint16_t>()")));
-    uint32_t                    readUInt32() __attribute__ ((deprecated("Use template readValue<uint32_t>()")));
     std::string                 toString(void);
     bool                        writeValue(const uint8_t* data, size_t length, bool response = false);
     bool                        writeValue(const std::vector<uint8_t>& v, bool response = false);


### PR DESCRIPTION
Removes the response parameter from remote characteristic subscribe/unsubscribe functions
as a response is always required for this operation as per BLE specs.

Removes the deprecated functions from remote characteristic/descriptor.