### PR TITLE
[Breaking] Update server callbacks to use NimBLEConnInfo.

### DIFF
--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -128,41 +128,27 @@ public:
      * @brief Handle a client connection.
      * This is called when a client connects.
      * @param [in] pServer A pointer to the %BLE server that received the client connection.
-     */
-    virtual void onConnect(NimBLEServer* pServer);
-
-    /**
-     * @brief Handle a client connection.
-     * This is called when a client connects.
-     * @param [in] pServer A pointer to the %BLE server that received the client connection.
      * @param [in] desc A pointer to the connection description structure containig information
      * about the connection parameters.
      */
-    virtual void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
+    virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
 
     /**
-     * @brief Handle a client disconnection.
-     * This is called when a client disconnects.
-     * @param [in] pServer A reference to the %BLE server that received the existing client disconnection.
-     */
-    virtual void onDisconnect(NimBLEServer* pServer);
-
-     /**
      * @brief Handle a client disconnection.
      * This is called when a client discconnects.
      * @param [in] pServer A pointer to the %BLE server that received the client disconnection.
      * @param [in] desc A pointer to the connection description structure containig information
      * about the connection.
      */
-    virtual void onDisconnect(NimBLEServer* pServer, ble_gap_conn_desc* desc);
+    virtual void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason);
 
-     /**
+    /**
      * @brief Called when the connection MTU changes.
      * @param [in] MTU The new MTU value.
      * @param [in] desc A pointer to the connection description structure containig information
      * about the connection.
      */
-    virtual void onMTUChange(uint16_t MTU, ble_gap_conn_desc* desc);
+    virtual void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when a client requests a passkey for pairing.
@@ -170,15 +156,12 @@ public:
      */
     virtual uint32_t onPassKeyRequest();
 
-    //virtual void onPassKeyNotify(uint32_t pass_key);
-    //virtual bool onSecurityRequest();
-
     /**
      * @brief Called when the pairing procedure is complete.
      * @param [in] desc A pointer to the struct containing the connection information.\n
      * This can be used to check the status of the connection encryption/pairing.
      */
-    virtual void onAuthenticationComplete(ble_gap_conn_desc* desc);
+    virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
 
     /**
      * @brief Called when using numeric comparision for pairing.


### PR DESCRIPTION
Chnage the server callback functions that receive a ble_gap_conn_desc pointer to instead receive a NimBLEConnInfo reference.

* Add a reason parameter to the disconnect callback.

* Remove connect and disconnect callback that do not receive info parameters.