### PR TITLE
Add conn_handle to NimBLECharacteristic::notify to send notification/indication to a specific client

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -1,7 +1,7 @@
 /*
  * NimBLECharacteristic.cpp
  *
- *  Created: on Aug 25, 2022
+ *  Created: on Aug 27, 2022
  *      Author Gluhovsky
  *
  * NimBLECharacteristic.cpp
@@ -26,15 +26,6 @@
 #define NULL_HANDLE (0xffff)
 #define NIMBLE_SUB_NOTIFY   0x0001
 #define NIMBLE_SUB_INDICATE 0x0002
-
-// Quick swap, based on std::move
-template<typename T>
-void swap(T& x, T& y)
-{
-  T z = std::move(x);
-    x = std::move(y);
-    y = std::move(z);
-}
 
 static NimBLECharacteristicCallbacks defaultCallback;
 static const char* LOG_TAG = "NimBLECharacteristic";
@@ -427,9 +418,11 @@ void NimBLECharacteristic::indicate(const std::vector<uint8_t>& value) {
 /**
  * @brief Send a notification or indication.
  * @param[in] is_notification if true sends a notification, false sends an indication.
+ * @param[in] conn_handle The handle of the connection to a specific subscribed client,
+ * if negative (default) sends notification/indication to the all subscribed clients.
  */
-void NimBLECharacteristic::notify(bool is_notification) {
-    notify(m_value.data(), m_value.length(), is_notification);
+void NimBLECharacteristic::notify(bool is_notification, int16_t conn_handle) {
+    notify(m_value.data(), m_value.length(), is_notification, conn_handle);
 } // notify
 
 
@@ -437,9 +430,11 @@ void NimBLECharacteristic::notify(bool is_notification) {
  * @brief Send a notification or indication.
  * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
  * @param[in] is_notification if true sends a notification, false sends an indication.
+ * @param[in] conn_handle The handle of the connection to a specific subscribed client,
+ * if negative (default) sends notification/indication to the all subscribed clients.
  */
-void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_notification) {
-    notify(value.data(), value.size(), is_notification);
+void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_notification, int16_t conn_handle) {
+    notify(value.data(), value.size(), is_notification, conn_handle);
 } // notify
 
 
@@ -448,8 +443,10 @@ void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_not
  * @param[in] value A pointer to the data to send.
  * @param[in] length The length of the data to send.
  * @param[in] is_notification if true sends a notification, false sends an indication.
+ * @param[in] conn_handle The handle of the connection to a specific subscribed client,
+ * if negative (default) sends notification/indication to the all subscribed clients.
  */
-void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_notification) {
+void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_notification, int16_t conn_handle) {
     NIMBLE_LOGD(LOG_TAG, ">> notify: length: %d", length);
 
     if(!(m_properties & NIMBLE_PROPERTY::NOTIFY) &&
@@ -473,6 +470,11 @@ void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_n
     int rc = 0;
 
     for (auto &it : m_subscribedVec) {
+        // check if need a specific client
+        if ((conn_handle >= 0) && (it.first != conn_handle)) {
+            continue;
+        }
+
         uint16_t _mtu = getService()->getServer()->getPeerMTU(it.first) - 3;
 
         // check if connected and subscribed
@@ -528,45 +530,6 @@ void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_n
 
     NIMBLE_LOGD(LOG_TAG, "<< notify");
 } // Notify
-
-/**
- * @brief Send a notification or indication.
- * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
- * @param[in] conn_handle A best way to send notifications to specific client - ATT MTU handle of the connection to query.
- * @param[in] is_notification if true sends a notification, false sends an indication.
- */
-void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, int16_t conn_handle, bool is_notification) {
-    notify(value.data(), value.size(), conn_handle, is_notification);
-} // notify
-
-
-/**
- * @brief Send a notification or indication.
- * @param[in] value A pointer to the data to send.
- * @param[in] length The length of the data to send.
- * @param[in] conn_handle A best way to send notifications to specific client - ATT MTU handle of the connection to query.
- * @param[in] is_notification if true sends a notification, false sends an indication.
- */
-void NimBLECharacteristic::notify(const uint8_t* value, size_t length, int16_t conn_handle, bool is_notification)
-{
-    if (conn_handle <= 0) {
-        // Send a notification or indication to all clients
-        notify(value, length, is_notification);
-    } else {
-        std::vector<std::pair<uint16_t, uint16_t>> subscribedVec;
-        for (auto &it : m_subscribedVec) {
-            if (it.first == conn_handle)
-                subscribedVec.push_back(it);
-        }
-        // store m_subscribedVec
-        ::swap(subscribedVec, m_subscribedVec);
-        // Send a notification or indication to specific client
-        notify(value, length, is_notification);
-        // restore m_subscribedVec
-        ::swap(subscribedVec, m_subscribedVec);
-        subscribedVec.clear();
-    }
-} // notify
 
 
 /**

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -418,8 +418,7 @@ void NimBLECharacteristic::indicate(const std::vector<uint8_t>& value) {
 /**
  * @brief Send a notification or indication.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle The handle of the connection to a specific subscribed client,
- * if negative (default) sends notification/indication to the all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
  */
 void NimBLECharacteristic::notify(bool is_notification, int16_t conn_handle) {
     notify(m_value.data(), m_value.length(), is_notification, conn_handle);
@@ -430,8 +429,7 @@ void NimBLECharacteristic::notify(bool is_notification, int16_t conn_handle) {
  * @brief Send a notification or indication.
  * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle The handle of the connection to a specific subscribed client,
- * if negative (default) sends notification/indication to the all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
  */
 void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_notification, int16_t conn_handle) {
     notify(value.data(), value.size(), is_notification, conn_handle);
@@ -443,8 +441,7 @@ void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_not
  * @param[in] value A pointer to the data to send.
  * @param[in] length The length of the data to send.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle The handle of the connection to a specific subscribed client,
- * if negative (default) sends notification/indication to the all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
  */
 void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_notification, int16_t conn_handle) {
     NIMBLE_LOGD(LOG_TAG, ">> notify: length: %d", length);

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -1,6 +1,11 @@
 /*
  * NimBLECharacteristic.cpp
  *
+ *  Created: on Aug 25, 2022
+ *      Author Gluhovsky
+ *
+ * NimBLECharacteristic.cpp
+ *
  *  Created: on March 3, 2020
  *      Author H2zero
  *
@@ -21,6 +26,15 @@
 #define NULL_HANDLE (0xffff)
 #define NIMBLE_SUB_NOTIFY   0x0001
 #define NIMBLE_SUB_INDICATE 0x0002
+
+// Quick swap, based on std::move
+template<typename T>
+void swap(T& x, T& y)
+{
+  T z = std::move(x);
+    x = std::move(y);
+    y = std::move(z);
+}
 
 static NimBLECharacteristicCallbacks defaultCallback;
 static const char* LOG_TAG = "NimBLECharacteristic";
@@ -514,6 +528,45 @@ void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_n
 
     NIMBLE_LOGD(LOG_TAG, "<< notify");
 } // Notify
+
+/**
+ * @brief Send a notification or indication.
+ * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
+ * @param[in] conn_handle A best way to send notifications to specific client - ATT MTU handle of the connection to query.
+ * @param[in] is_notification if true sends a notification, false sends an indication.
+ */
+void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, int16_t conn_handle, bool is_notification) {
+    notify(value.data(), value.size(), conn_handle, is_notification);
+} // notify
+
+
+/**
+ * @brief Send a notification or indication.
+ * @param[in] value A pointer to the data to send.
+ * @param[in] length The length of the data to send.
+ * @param[in] conn_handle A best way to send notifications to specific client - ATT MTU handle of the connection to query.
+ * @param[in] is_notification if true sends a notification, false sends an indication.
+ */
+void NimBLECharacteristic::notify(const uint8_t* value, size_t length, int16_t conn_handle, bool is_notification)
+{
+    if (conn_handle <= 0) {
+        // Send a notification or indication to all clients
+        notify(value, length, is_notification);
+    } else {
+        std::vector<std::pair<uint16_t, uint16_t>> subscribedVec;
+        for (auto &it : m_subscribedVec) {
+            if (it.first == conn_handle)
+                subscribedVec.push_back(it);
+        }
+        // store m_subscribedVec
+        ::swap(subscribedVec, m_subscribedVec);
+        // Send a notification or indication to specific client
+        notify(value, length, is_notification);
+        // restore m_subscribedVec
+        ::swap(subscribedVec, m_subscribedVec);
+        subscribedVec.clear();
+    }
+} // notify
 
 
 /**

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -1,11 +1,6 @@
 /*
  * NimBLECharacteristic.cpp
  *
- *  Created: on Aug 27, 2022
- *      Author Gluhovsky
- *
- * NimBLECharacteristic.cpp
- *
  *  Created: on March 3, 2020
  *      Author H2zero
  *
@@ -418,9 +413,9 @@ void NimBLECharacteristic::indicate(const std::vector<uint8_t>& value) {
 /**
  * @brief Send a notification or indication.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or BLE_HCI_LE_CONN_HANDLE_MAX + 1 to send notification to all subscribed clients.
  */
-void NimBLECharacteristic::notify(bool is_notification, int16_t conn_handle) {
+void NimBLECharacteristic::notify(bool is_notification, uint16_t conn_handle) {
     notify(m_value.data(), m_value.length(), is_notification, conn_handle);
 } // notify
 
@@ -429,9 +424,9 @@ void NimBLECharacteristic::notify(bool is_notification, int16_t conn_handle) {
  * @brief Send a notification or indication.
  * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or BLE_HCI_LE_CONN_HANDLE_MAX + 1 to send notification to all subscribed clients.
  */
-void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_notification, int16_t conn_handle) {
+void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_notification, uint16_t conn_handle) {
     notify(value.data(), value.size(), is_notification, conn_handle);
 } // notify
 
@@ -441,9 +436,9 @@ void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, bool is_not
  * @param[in] value A pointer to the data to send.
  * @param[in] length The length of the data to send.
  * @param[in] is_notification if true sends a notification, false sends an indication.
- * @param[in] conn_handle Connection handle to send individual notification, or -1 to send notification to all subscribed clients.
+ * @param[in] conn_handle Connection handle to send individual notification, or BLE_HCI_LE_CONN_HANDLE_MAX + 1 to send notification to all subscribed clients.
  */
-void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_notification, int16_t conn_handle) {
+void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_notification, uint16_t conn_handle) {
     NIMBLE_LOGD(LOG_TAG, ">> notify: length: %d", length);
 
     if(!(m_properties & NIMBLE_PROPERTY::NOTIFY) &&
@@ -468,7 +463,7 @@ void NimBLECharacteristic::notify(const uint8_t* value, size_t length, bool is_n
 
     for (auto &it : m_subscribedVec) {
         // check if need a specific client
-        if ((conn_handle >= 0) && (it.first != conn_handle)) {
+        if ((conn_handle <= BLE_HCI_LE_CONN_HANDLE_MAX) && (it.first != conn_handle)) {
             continue;
         }
 

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -1,7 +1,7 @@
 /*
  * NimBLECharacteristic.cpp
  *
- *  Created: on Aug 25, 2022
+ *  Created: on Aug 27, 2022
  *      Author Gluhovsky
  *
  * NimBLECharacteristic.h
@@ -88,11 +88,9 @@ public:
     void              indicate();
     void              indicate(const uint8_t* value, size_t length);
     void              indicate(const std::vector<uint8_t>& value);
-    void              notify(bool is_notification = true);
-    void              notify(const uint8_t* value, size_t length, bool is_notification = true);
-    void              notify(const std::vector<uint8_t>& value, bool is_notification = true);
-    void              notify(const uint8_t* value, size_t length, int16_t conn_handle, bool is_notification = true);
-    void              notify(const std::vector<uint8_t>& value, int16_t conn_handle, bool is_notification = true);
+    void              notify(bool is_notification = true, int16_t conn_handle = (-1));
+    void              notify(const uint8_t* value, size_t length, bool is_notification = true, int16_t conn_handle = (-1));
+    void              notify(const std::vector<uint8_t>& value, bool is_notification = true, int16_t conn_handle = (-1));
     size_t            getSubscribedCount();
     void              addDescriptor(NimBLEDescriptor *pDescriptor);
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -1,4 +1,9 @@
 /*
+ * NimBLECharacteristic.cpp
+ *
+ *  Created: on Aug 25, 2022
+ *      Author Gluhovsky
+ *
  * NimBLECharacteristic.h
  *
  *  Created: on March 3, 2020
@@ -86,6 +91,8 @@ public:
     void              notify(bool is_notification = true);
     void              notify(const uint8_t* value, size_t length, bool is_notification = true);
     void              notify(const std::vector<uint8_t>& value, bool is_notification = true);
+    void              notify(const uint8_t* value, size_t length, int16_t conn_handle, bool is_notification = true);
+    void              notify(const std::vector<uint8_t>& value, int16_t conn_handle, bool is_notification = true);
     size_t            getSubscribedCount();
     void              addDescriptor(NimBLEDescriptor *pDescriptor);
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -1,9 +1,4 @@
 /*
- * NimBLECharacteristic.cpp
- *
- *  Created: on Aug 27, 2022
- *      Author Gluhovsky
- *
  * NimBLECharacteristic.h
  *
  *  Created: on March 3, 2020
@@ -88,9 +83,9 @@ public:
     void              indicate();
     void              indicate(const uint8_t* value, size_t length);
     void              indicate(const std::vector<uint8_t>& value);
-    void              notify(bool is_notification = true, int16_t conn_handle = (-1));
-    void              notify(const uint8_t* value, size_t length, bool is_notification = true, int16_t conn_handle = (-1));
-    void              notify(const std::vector<uint8_t>& value, bool is_notification = true, int16_t conn_handle = (-1));
+    void              notify(bool is_notification = true, uint16_t conn_handle = BLE_HCI_LE_CONN_HANDLE_MAX + 1);
+    void              notify(const uint8_t* value, size_t length, bool is_notification = true, uint16_t conn_handle = BLE_HCI_LE_CONN_HANDLE_MAX + 1);
+    void              notify(const std::vector<uint8_t>& value, bool is_notification = true, uint16_t conn_handle = BLE_HCI_LE_CONN_HANDLE_MAX + 1);
     size_t            getSubscribedCount();
     void              addDescriptor(NimBLEDescriptor *pDescriptor);
     NimBLEDescriptor* getDescriptorByUUID(const char* uuid);


### PR DESCRIPTION
@param[in] conn_handle The handle of the connection to a specific subscribed client,
if negative (default) sends notification/indication to the all subscribed clients.