### PR TITLE
Remove deprecated API in case of ESP-IDF V5.

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -925,10 +925,12 @@ void NimBLEDevice::deinit(bool clearAll) {
     if (ret == 0) {
         nimble_port_deinit();
 #ifdef ESP_PLATFORM
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
         ret = esp_nimble_hci_and_controller_deinit();
         if (ret != ESP_OK) {
             NIMBLE_LOGE(LOG_TAG, "esp_nimble_hci_and_controller_deinit() failed with error: %d", ret);
         }
+#endif
 #endif
         initialized = false;
         m_synced = false;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -866,6 +866,7 @@ void NimBLEDevice::init(const std::string &deviceName) {
 
         esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
         esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
 #if  defined (CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
         bt_cfg.bluetooth_mode = ESP_BT_MODE_BLE;
@@ -879,6 +880,7 @@ void NimBLEDevice::init(const std::string &deviceName) {
         ESP_ERROR_CHECK(esp_bt_controller_init(&bt_cfg));
         ESP_ERROR_CHECK(esp_bt_controller_enable(ESP_BT_MODE_BLE));
         ESP_ERROR_CHECK(esp_nimble_hci_init());
+#endif
 #endif
         nimble_port_init();
 


### PR DESCRIPTION
`esp_nimble_hci_and_controller_deinit` function has been [removed from the API](https://github.com/espressif/esp-idf/blob/0a93ee1337c15668c7f9998a53822f281a17670e/docs/en/migration-guides/release-5.x/bluetooth-low-energy.rst) in ESP IDF version 5.0. Add a compile guard to prevent build errors.