### PR TITLE
Return a pointer to the Value object

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -236,14 +236,13 @@ NimBLEUUID NimBLECharacteristic::getUUID() {
  * @brief Retrieve the current value of the characteristic.
  * @return The NimBLEAttValue containing the current characteristic value.
  */
-NimBLEAttValue NimBLECharacteristic::getValue(time_t *timestamp) {
+NimBLEAttValue* NimBLECharacteristic::getValue(time_t *timestamp) {
     if(timestamp != nullptr) {
         m_value.getValue(timestamp);
     }
 
-    return m_value;
+    return &m_value;
 } // getValue
-
 
 /**
  * @brief Retrieve the the current data length of the characteristic.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -95,7 +95,7 @@ public:
     void              removeDescriptor(NimBLEDescriptor *pDescriptor, bool deleteDsc = false);
     NimBLEService*    getService();
     uint16_t          getProperties();
-    NimBLEAttValue    getValue(time_t *timestamp = nullptr);
+    NimBLEAttValue*   getValue(time_t *timestamp = nullptr);
     size_t            getDataLength();
     void              setValue(const uint8_t* data, size_t size);
     void              setValue(const std::vector<uint8_t>& vec);


### PR DESCRIPTION
Otherwise we get a copy, and the copy seems to clobber the data we want

Before this commit, calling `getValue()` would return a copy of the underlying `NimBLEAttValue` object.  It seems like the copy doesn't necessarily copy the underlying data stored in the value.  In this commit, I changed it to just return a pointer (which fixes my application), but maybe the class should know how to copy its underlying data.

I'm not sure if this is the best fix (I'm not a pro C++ developer), but as I said this fixes my app.

Thanks!