### PR TITLE
Fixed unhandled exception on handleGapEvent

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -261,6 +261,12 @@ int NimBLECharacteristic::handleGapEvent(uint16_t conn_handle, uint16_t attr_han
                              struct ble_gatt_access_ctxt *ctxt,
                              void *arg)
 {
+    if (conn_handle > BLE_HCI_LE_CONN_HANDLE_MAX)
+    {
+        NIMBLE_LOGW(LOG_TAG, "Conn_handle (%d) is above the maximum value (%d)", conn_handle, BLE_HCI_LE_CONN_HANDLE_MAX);
+        return BLE_ATT_ERR_INVALID_HANDLE;
+    }
+    
     const ble_uuid_t *uuid;
     int rc;
     NimBLEConnInfo peerInfo;


### PR DESCRIPTION
Somehow, the `conn_handle` can have the value of `0xffff`. Not sure why or how, but anyway it should be managed before moving forward on `NimBLECharacteristic::handleGapEvent`. Otherwise, an unhandled exception will occur on `assert(rc == 0);`