### PR TITLE
Implement a means of asynchronous pin injections for Numeric Comparison and PassKey Input

### DIFF
--- a/examples/Advanced/NimBLE_Server/main/main.cpp
+++ b/examples/Advanced/NimBLE_Server/main/main.cpp
@@ -44,18 +44,26 @@ class ServerCallbacks: public NimBLEServerCallbacks {
     
 /********************* Security handled here **********************
 ****** Note: these are the same return values as defaults ********/
-    uint32_t onPassKeyRequest(){
-        printf("Server Passkey Request\n");
+    uint32_t onPassKeyDisplay(){
+        printf("Server Passkey Display\n");
         /** This should return a random 6 digit number for security 
          *  or make your own static passkey as done here.
          */
         return 123456; 
     };
 
-    bool onConfirmPIN(uint32_t pass_key){
+    void onPassKeyEntry(const BLEAddress& address){
+        printf("Server Passkey Entry\n");
+        /** This should prompt the user to enter the passkey displayed
+         * on the peer device.
+         */
+        NimBLEDevice()::getServer()->injectPassKey(address, 123456)
+    };
+
+    void onConfirmPIN(const BLEAddress& address, uint32_t pass_key){
         printf("The passkey YES/NO number: %d\n", pass_key);
-        /** Return false if passkeys don't match. */
-        return true; 
+        /** Inject false if passkeys don't match. */
+        NimBLEDevice()::getServer()->injectConfirmPIN(address, true);
     };
 
     void onAuthenticationComplete(NimBLEConnInfo& connInfo){

--- a/examples/Advanced/NimBLE_Server/main/main.cpp
+++ b/examples/Advanced/NimBLE_Server/main/main.cpp
@@ -57,13 +57,13 @@ class ServerCallbacks: public NimBLEServerCallbacks {
         /** This should prompt the user to enter the passkey displayed
          * on the peer device.
          */
-        NimBLEDevice()::getServer()->injectPassKey(address, 123456)
+        NimBLEDevice::getServer()->injectPassKey(address, 123456)
     };
 
     void onConfirmPIN(const BLEAddress& address, uint32_t pass_key){
         printf("The passkey YES/NO number: %d\n", pass_key);
         /** Inject false if passkeys don't match. */
-        NimBLEDevice()::getServer()->injectConfirmPIN(address, true);
+        NimBLEDevice::getServer()->injectConfirmPIN(address, true);
     };
 
     void onAuthenticationComplete(NimBLEConnInfo& connInfo){

--- a/examples/Advanced/NimBLE_Server/main/main.cpp
+++ b/examples/Advanced/NimBLE_Server/main/main.cpp
@@ -57,7 +57,7 @@ class ServerCallbacks: public NimBLEServerCallbacks {
         /** This should prompt the user to enter the passkey displayed
          * on the peer device.
          */
-        NimBLEDevice::getServer()->injectPassKey(address, 123456)
+        NimBLEDevice::getServer()->injectPassKey(address, 123456);
     };
 
     void onConfirmPIN(const BLEAddress& address, uint32_t pass_key){

--- a/examples/basic/BLE_notify/main/main.cpp
+++ b/examples/basic/BLE_notify/main/main.cpp
@@ -57,14 +57,19 @@ class MyServerCallbacks: public BLEServerCallbacks {
     }
 /***************** New - Security handled here ********************
 ****** Note: these are the same return values as defaults ********/
-  uint32_t onPassKeyRequest(){
-    printf("Server PassKeyRequest\n");
+  uint32_t onPassKeyDisplay(){
+    printf("Server PassKeyDisplay\n");
     return 123456; 
   }
 
-  bool onConfirmPIN(uint32_t pass_key){
+  void onPassKeyEntry(const BLEAddress& address){
+    printf("Server PassKeyEntry\n");
+    BLEDevice::getServer()->injectPassKey(address, 123456);
+  }
+
+  void onConfirmPIN(const BLEAddress& address, uint32_t pass_key){
     printf("The passkey YES/NO number: %d\n", pass_key);
-    return true; 
+    BLEDevice::getServer()->injectConfirmPIN(address, true);
   }
 
   void onAuthenticationComplete(BLEConnInfo& connInfo){

--- a/examples/basic/BLE_uart/main/main.cpp
+++ b/examples/basic/BLE_uart/main/main.cpp
@@ -59,14 +59,19 @@ class MyServerCallbacks: public BLEServerCallbacks {
     }
   /***************** New - Security handled here ********************
   ****** Note: these are the same return values as defaults ********/
-    uint32_t onPassKeyRequest(){
-      printf("Server PassKeyRequest\n");
+    uint32_t onPassKeyDisplay(){
+      printf("Server PassKeyDisplay\n");
       return 123456; 
     }
 
-    bool onConfirmPIN(uint32_t pass_key){
+    void onPassKeyEntry(const BLEAddress& address){
+      printf("Server PassKeyEntry\n");
+      BLEDevice::getServer()->injectPassKey(address, 123456);
+    }
+
+    void onConfirmPIN(const BLEAddress& address, uint32_t pass_key){
       printf("The passkey YES/NO number: %d\n", pass_key);
-      return true; 
+      BLEDevice::getServer()->injectConfirmPIN(address, true);
     }
 
     void onAuthenticationComplete(BLEConnInfo& connInfo){

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -264,6 +264,61 @@ void NimBLEServer::advertiseOnDisconnect(bool aod) {
 #endif
 
 /**
+ * @brief Inject the provided passkey into the Security Manager
+ * @param [in] address Address to the peer connection
+ * @param [in] pin The 6-digit pin to inject
+ */
+void NimBLEServer::injectPassKey(const NimBLEAddress& address, uint32_t pin) {
+    NimBLEConnInfo peerInfo;
+    ble_addr_t peerAddr;
+    int rc = 0;
+    struct ble_sm_io pkey = {0,0};
+
+    pkey.action = BLE_SM_IOACT_INPUT;
+    pkey.passkey = pin;
+
+    peerAddr.type = address.getType();
+    memcpy(peerAddr.val, address.getNative(), 6);
+
+    rc = ble_gap_conn_find_by_addr(&peerAddr, &peerInfo.m_desc);
+    if (rc != 0) {
+        NIMBLE_LOGW(LOG_TAG, "BLE_SM_IOACT_INPUT; ble_gap_conn_find_by_addr result: %d", rc);
+        return;
+    }
+
+    rc = ble_sm_inject_io(peerInfo.getConnHandle(), &pkey);
+
+    NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_INPUT; ble_sm_inject_io result: %d", rc);
+}
+
+/**
+ * @brief Inject the provided numeric comparison response into the Security Manager
+ * @param [in] address Address to the peer connection
+ * @param [in] accept Whether the user confirmed or declined the comparison
+ */
+void NimBLEServer::injectConfirmPIN(const NimBLEAddress& address, bool accept) {
+    NimBLEConnInfo peerInfo;
+    ble_addr_t peerAddr;
+    int rc = 0;
+    struct ble_sm_io pkey = {0,0};
+
+    pkey.action = BLE_SM_IOACT_NUMCMP;
+    pkey.numcmp_accept = accept;
+
+    peerAddr.type = address.getType();
+    memcpy(peerAddr.val, address.getNative(), 6);
+
+    rc = ble_gap_conn_find_by_addr(&peerAddr, &peerInfo.m_desc);
+    if (rc != 0) {
+        NIMBLE_LOGW(LOG_TAG, "BLE_SM_IOACT_NUMCMP; ble_gap_conn_find_by_addr result: %d", rc);
+        return;
+    }
+
+    rc = ble_sm_inject_io(peerInfo.getConnHandle(), &pkey);
+    NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_NUMCMP; ble_sm_inject_io result: %d", rc);
+}
+
+/**
  * @brief Return the number of connected clients.
  * @return The number of connected clients.
  */
@@ -528,19 +583,20 @@ int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
                 // if the (static)passkey is the default, check the callback for custom value
                 // both values default to the same.
                 if(pkey.passkey == 123456) {
-                    pkey.passkey = pServer->m_pServerCallbacks->onPassKeyRequest();
+                    pkey.passkey = pServer->m_pServerCallbacks->onPassKeyDisplay();
                 }
                 rc = ble_sm_inject_io(event->passkey.conn_handle, &pkey);
                 NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_DISP; ble_sm_inject_io result: %d", rc);
 
             } else if (event->passkey.params.action == BLE_SM_IOACT_NUMCMP) {
                 NIMBLE_LOGD(LOG_TAG, "Passkey on device's display: %" PRIu32, event->passkey.params.numcmp);
-                pkey.action = event->passkey.params.action;
-                pkey.numcmp_accept = pServer->m_pServerCallbacks->onConfirmPIN(event->passkey.params.numcmp);
 
-                rc = ble_sm_inject_io(event->passkey.conn_handle, &pkey);
-                NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_NUMCMP; ble_sm_inject_io result: %d", rc);
+                rc = ble_gap_conn_find(event->passkey.conn_handle, &peerInfo.m_desc);
+                if(rc != 0) {
+                    return BLE_ATT_ERR_INVALID_HANDLE;
+                }
 
+                pServer->m_pServerCallbacks->onConfirmPIN(peerInfo.getAddress(), event->passkey.params.numcmp);
             //TODO: Handle out of band pairing
             } else if (event->passkey.params.action == BLE_SM_IOACT_OOB) {
                 static uint8_t tem_oob[16] = {0};
@@ -553,12 +609,13 @@ int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
             //////////////////////////////////
             } else if (event->passkey.params.action == BLE_SM_IOACT_INPUT) {
                 NIMBLE_LOGD(LOG_TAG, "Enter the passkey");
-                pkey.action = event->passkey.params.action;
-                pkey.passkey = pServer->m_pServerCallbacks->onPassKeyRequest();
 
-                rc = ble_sm_inject_io(event->passkey.conn_handle, &pkey);
-                NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_INPUT; ble_sm_inject_io result: %d", rc);
+                rc = ble_gap_conn_find(event->passkey.conn_handle, &peerInfo.m_desc);
+                if(rc != 0) {
+                    return BLE_ATT_ERR_INVALID_HANDLE;
+                }
 
+                pServer->m_pServerCallbacks->onPassKeyEntry(peerInfo.getAddress());
             } else if (event->passkey.params.action == BLE_SM_IOACT_NONE) {
                 NIMBLE_LOGD(LOG_TAG, "No passkey action required");
             }
@@ -851,18 +908,23 @@ void NimBLEServerCallbacks::onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo) 
     NIMBLE_LOGD("NimBLEServerCallbacks", "onMTUChange(): Default");
 } // onMTUChange
 
-uint32_t NimBLEServerCallbacks::onPassKeyRequest(){
-    NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyRequest: default: 123456");
+uint32_t NimBLEServerCallbacks::onPassKeyDisplay(){
+    NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyDisplay: default: 123456");
     return 123456;
-} //onPassKeyRequest
+} //onPassKeyDisplay
+
+uint32_t NimBLEServerCallbacks::onPassKeyEntry(const NimBLEAddress& address){
+    NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyEntry: default: 123456");
+    NimBLEDevice::getServer()->injectPassKey(address, 123456);
+} //onPassKeyEntry
 
 void NimBLEServerCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onAuthenticationComplete: default");
 } // onAuthenticationComplete
 
-bool NimBLEServerCallbacks::onConfirmPIN(uint32_t pin){
+bool NimBLEServerCallbacks::onConfirmPIN(const NimBLEAddress& address, uint32_t pin){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onConfirmPIN: default: true");
-    return true;
+    NimBLEDevice::getServer()->injectConfirmPin(address, true);
 } // onConfirmPIN
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -913,18 +913,18 @@ uint32_t NimBLEServerCallbacks::onPassKeyDisplay(){
     return 123456;
 } //onPassKeyDisplay
 
-uint32_t NimBLEServerCallbacks::onPassKeyEntry(const NimBLEAddress& address){
+void NimBLEServerCallbacks::onPassKeyEntry(const NimBLEAddress& address){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyEntry: default: 123456");
     NimBLEDevice::getServer()->injectPassKey(address, 123456);
 } //onPassKeyEntry
 
-void NimBLEServerCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo){
-    NIMBLE_LOGD("NimBLEServerCallbacks", "onAuthenticationComplete: default");
-} // onAuthenticationComplete
-
-bool NimBLEServerCallbacks::onConfirmPIN(const NimBLEAddress& address, uint32_t pin){
+void NimBLEServerCallbacks::onConfirmPIN(const NimBLEAddress& address, uint32_t pin){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onConfirmPIN: default: true");
     NimBLEDevice::getServer()->injectConfirmPin(address, true);
 } // onConfirmPIN
+
+void NimBLEServerCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo){
+    NIMBLE_LOGD("NimBLEServerCallbacks", "onAuthenticationComplete: default");
+} // onAuthenticationComplete
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -920,7 +920,7 @@ void NimBLEServerCallbacks::onPassKeyEntry(const NimBLEAddress& address){
 
 void NimBLEServerCallbacks::onConfirmPIN(const NimBLEAddress& address, uint32_t pin){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onConfirmPIN: default: true");
-    NimBLEDevice::getServer()->injectConfirmPin(address, true);
+    NimBLEDevice::getServer()->injectConfirmPIN(address, true);
 } // onConfirmPIN
 
 void NimBLEServerCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo){

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -81,6 +81,8 @@ public:
 #if !CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
     void                   advertiseOnDisconnect(bool);
 #endif
+    void                   injectPassKey(const NimBLEAddress& address, uint32_t pin);
+    void                   injectConfirmPIN(const NimBLEAddress& address, bool accept);
 
 private:
     NimBLEServer();
@@ -152,10 +154,25 @@ public:
     virtual void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo);
 
     /**
-     * @brief Called when a client requests a passkey for pairing.
+     * @brief Called when a client requests a passkey for pairing (display).
      * @return The passkey to be sent to the client.
      */
-    virtual uint32_t onPassKeyRequest();
+    virtual uint32_t onPassKeyDisplay();
+
+    /**
+     * @brief Called when a client requests a passkey for pairing (input).
+     * @param [in] address The address to the peer device making the pairing attempt.
+     * Should be passed back to NimBLEServer::injectPassKey
+     */
+    virtual void onPassKeyEntry(const NimBLEAddress& address);
+
+    /**
+     * @brief Called when using numeric comparision for pairing.
+     * @param [in] address The address to the peer device making the pairing attempt.
+     * Should be passed back to NimBLEServer::injectConfirmPIN
+     * @param [in] pin The pin to compare with the client.
+     */
+    virtual void onConfirmPIN(const NimBLEAddress& address, uint32_t pin);
 
     /**
      * @brief Called when the pairing procedure is complete.
@@ -163,13 +180,6 @@ public:
      * about the peer connection parameters.
      */
     virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
-
-    /**
-     * @brief Called when using numeric comparision for pairing.
-     * @param [in] pin The pin to compare with the client.
-     * @return True to accept the pin.
-     */
-    virtual bool onConfirmPIN(uint32_t pin);
 }; // NimBLEServerCallbacks
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */


### PR DESCRIPTION
Fixes #114

Summary of changes:

- Split `onPassKeyRequest` into two separate functions:
  - `onPassKeyDisplay` which requests the pin (similar to old functionality)
  - `onPassKeyEntry` which notifies the application to prompt the user for a pin number. No return value
- Changed `onConfirmPIN` to lack return value, instead just notifies the app to display the pin number
- Added two functions to the NimBLEServer class: `injectPassKey` and `injectConfirmPIN`, which should be called when the user enters the PIN or presses confirm/cancel respectively.