### PR TITLE
`gptimer` is used from esp-nimble-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ idf_component_register(
   REQUIRES
     bt
     nvs_flash
+    driver
   PRIV_REQUIRES
     ${ESP_NIMBLE_PRIV_REQUIRES}
 )


### PR DESCRIPTION
without `driver` as requirement compile fails sometimes.