### PR TITLE
Update NimBLEAdvertising.cpp

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -138,6 +138,7 @@ void NimBLEAdvertising::addTxPower() {
  */
 void NimBLEAdvertising::setName(const std::string &name) {
     m_name.assign(name.begin(), name.end());
+    m_name[name.length()] = 0;
     m_advData.name = &m_name[0];
     m_advData.name_len = m_name.size();
     m_advDataSet = false;

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -138,7 +138,7 @@ void NimBLEAdvertising::addTxPower() {
  */
 void NimBLEAdvertising::setName(const std::string &name) {
     m_name.assign(name.begin(), name.end());
-    m_name[name.length()] = 0;
+    if (name.length() <= 19) m_name[name.length()] = 0;
     m_advData.name = &m_name[0];
     m_advData.name_len = m_name.size();
     m_advDataSet = false;


### PR DESCRIPTION
Null terminate the m_name vector because for some reason if you shorten the advertising name it will keep the length the same as the longest name that has been set until the uP is restarted. This means that if you set the name to "longest" and then set it to "short" it will advertise as "shortst" (note two letters from the end of "longest".