### PR TITLE
Fix inconsistent use of time units

### DIFF
--- a/docs/Improvements_and_updates.md
+++ b/docs/Improvements_and_updates.md
@@ -66,7 +66,7 @@ If false the service is only removed from visibility by clients. The pointers to
 # Advertising
 `NimBLEAdvertising::start`
 
-Now takes 2 optional parameters, the first is the duration to advertise for (in seconds), the second is a callback that is invoked when advertising ends and takes a pointer to a `NimBLEAdvertising` object (similar to the `NimBLEScan::start` API).
+Now takes 2 optional parameters, the first is the duration to advertise for (in milliseconds), the second is a callback that is invoked when advertising ends and takes a pointer to a `NimBLEAdvertising` object (similar to the `NimBLEScan::start` API).
 
 This provides an opportunity to update the advertisement data if desired.
 

--- a/docs/Migration_guide.md
+++ b/docs/Migration_guide.md
@@ -255,7 +255,7 @@ Calling `NimBLEAdvertising::setAdvertisementData` will entirely replace any data
 
 > BLEAdvertising::start (NimBLEAdvertising::start)
 
-Now takes 2 optional parameters, the first is the duration to advertise for (in seconds), the second is a callback that is invoked when advertising ends and takes a pointer to a `NimBLEAdvertising` object (similar to the `NimBLEScan::start` API).
+Now takes 2 optional parameters, the first is the duration to advertise for (in milliseconds), the second is a callback that is invoked when advertising ends and takes a pointer to a `NimBLEAdvertising` object (similar to the `NimBLEScan::start` API).
 This provides an opportunity to update the advertisement data if desired.  
 <br/>
 

--- a/examples/Advanced/NimBLE_Client/main/main.cpp
+++ b/examples/Advanced/NimBLE_Client/main/main.cpp
@@ -146,8 +146,8 @@ bool connectToServer() {
          *  Min interval: 12 * 1.25ms = 15, Max interval: 12 * 1.25ms = 15, 0 latency, 12 * 10ms = 120ms timeout
          */
         pClient->setConnectionParams(6,6,0,15);
-        /** Set how long we are willing to wait for the connection to complete (seconds), default is 30. */
-        pClient->setConnectTimeout(5);
+        /** Set how long we are willing to wait for the connection to complete (milliseconds), default is 30000. */
+        pClient->setConnectTimeout(5 * 1000);
 
 
         if (!pClient->connect(advDevice)) {
@@ -358,7 +358,7 @@ void app_main (void){
      *  but will use more energy from both devices
      */
     pScan->setActiveScan(true);
-    /** Start scanning for advertisers for the scan time specified (in seconds) 0 = forever
+    /** Start scanning for advertisers for the scan time specified (in milliseconds) 0 = forever
      *  Optional callback for when scanning stops.
      */
     pScan->start(scanTime);

--- a/examples/Bluetooth_5/NimBLE_extended_client/main/main.cpp
+++ b/examples/Bluetooth_5/NimBLE_extended_client/main/main.cpp
@@ -154,7 +154,7 @@ void app_main (void) {
      */
     pScan->setActiveScan(true);
 
-    /*  Start scanning for advertisers for the scan time specified (in seconds) 0 = forever
+    /*  Start scanning for advertisers for the scan time specified (in milliseconds) 0 = forever
      *  Optional callback for when scanning stops.
      */
     pScan->start(scanTime);

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -459,7 +459,7 @@ void NimBLEScan::onHostSync() {
 
 /**
  * @brief Start scanning and block until scanning has been completed.
- * @param [in] duration The duration in seconds for which to scan.
+ * @param [in] duration The duration in milliseconds for which to scan.
  * @param [in] is_continue Set to true to save previous scan results, false to clear them.
  * @return The scan results.
  */


### PR DESCRIPTION
Correct times when values in milliseconds are being referred to as if they were in seconds. In examples, documentation and comments. 