### PR TITLE
Change advertising callback from raw pointer to std::function

### DIFF
--- a/src/NimBLEAdvertisedDevice.cpp
+++ b/src/NimBLEAdvertisedDevice.cpp
@@ -203,6 +203,24 @@ std::string NimBLEAdvertisedDevice::getURI() {
     return "";
 } // getURI
 
+/**
+ * @brief Get the data from any type available in the advertisement
+ * @param [in] type The advertised data type BLE_HS_ADV_TYPE
+ * @return The data available under the type `type`
+*/
+std::string NimBLEAdvertisedDevice::getPayloadByType(uint16_t type) {
+    size_t data_loc = 0;
+
+    if(findAdvField(type, 0, &data_loc) > 0) {
+        ble_hs_adv_field *field = (ble_hs_adv_field *)&m_payload[data_loc];
+        if(field->length > 1) {
+            return std::string((char*)field->value, field->length - 1);
+        }
+    }
+
+    return "";
+} // getPayloadByType
+
 
 /**
  * @brief Get the advertised name.
@@ -555,6 +573,14 @@ bool NimBLEAdvertisedDevice::haveManufacturerData() {
 bool NimBLEAdvertisedDevice::haveURI() {
     return findAdvField(BLE_HS_ADV_TYPE_URI) > 0;
 } // haveURI
+
+/**
+ * @brief Does this advertisement have a adv type `type`?
+ * @return True if there is a `type` present.
+*/
+bool NimBLEAdvertisedDevice::haveType(uint16_t type) {
+    return findAdvField(type) > 0;
+}
 
 
 /**

--- a/src/NimBLEAdvertisedDevice.h
+++ b/src/NimBLEAdvertisedDevice.h
@@ -53,6 +53,7 @@ public:
     uint8_t         getManufacturerDataCount();
     std::string     getManufacturerData(uint8_t index = 0);
     std::string     getURI();
+    std::string     getPayloadByType(uint16_t type);
 
     /**
      * @brief A template to convert the service data to <type\>.
@@ -134,6 +135,7 @@ public:
     bool            haveAdvInterval();
     bool            haveTargetAddress();
     bool            haveURI();
+    bool            haveType(uint16_t type);
     std::string     toString();
     bool            isConnectable();
     bool            isLegacyAdvertisement();

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -402,7 +402,7 @@ void NimBLEAdvertising::setScanResponseData(NimBLEAdvertisementData& advertiseme
  * @param [in] dirAddr The address of a peer to directly advertise to.
  * @return True if advertising started successfully.
  */
-bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdvertising *pAdv), NimBLEAddress* dirAddr) {
+bool NimBLEAdvertising::start(uint32_t duration, advCompleteCB_t advCompleteCB, NimBLEAddress* dirAddr) {
     NIMBLE_LOGD(LOG_TAG, ">> Advertising start: customAdvData: %d, customScanResponseData: %d",
                 m_customAdvData, m_customScanResponseData);
 

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -33,6 +33,7 @@
 #include "NimBLEUUID.h"
 #include "NimBLEAddress.h"
 
+#include <functional>
 #include <vector>
 
 /* COMPATIBILITY - DO NOT USE */
@@ -44,6 +45,10 @@
 #define ESP_BLE_ADV_FLAG_NON_LIMIT_DISC     (0x00 )
  /* ************************* */
 
+
+class NimBLEAdvertising;
+
+typedef std::function<void(NimBLEAdvertising*)> advCompleteCB_t;
 
 /**
  * @brief Advertisement data set by the programmer to be published by the %BLE server.
@@ -92,7 +97,7 @@ public:
     void addServiceUUID(const NimBLEUUID &serviceUUID);
     void addServiceUUID(const char* serviceUUID);
     void removeServiceUUID(const NimBLEUUID &serviceUUID);
-    bool start(uint32_t duration = 0, void (*advCompleteCB)(NimBLEAdvertising *pAdv) = nullptr, NimBLEAddress* dirAddr = nullptr);
+    bool start(uint32_t duration = 0, advCompleteCB_t advCompleteCB = nullptr, NimBLEAddress* dirAddr = nullptr);
     bool stop();
     void setAppearance(uint16_t appearance);
     void setName(const std::string &name);
@@ -129,7 +134,7 @@ private:
     bool                    m_customScanResponseData;
     bool                    m_scanResp;
     bool                    m_advDataSet;
-    void                    (*m_advCompCB)(NimBLEAdvertising *pAdv);
+    advCompleteCB_t         m_advCompCB{nullptr};
     uint8_t                 m_slaveItvl[4];
     uint32_t                m_duration;
     std::vector<uint8_t>    m_svcData16;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -569,8 +569,8 @@ int NimBLEDevice::getNumBonds() {
  * @brief Deletes all bonding information.
  */
 /*STATIC*/
-void NimBLEDevice::deleteAllBonds() {
-    ble_store_clear();
+int NimBLEDevice::deleteAllBonds() {
+    return ble_store_clear();
 }
 
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -172,7 +172,7 @@ public:
     static bool             deleteBond(const NimBLEAddress &address);
     static int              getNumBonds();
     static bool             isBonded(const NimBLEAddress &address);
-    static void             deleteAllBonds();
+    static int              deleteAllBonds();
     static NimBLEAddress    getBondedAddress(int index);
 #endif
 

--- a/src/NimBLEService.cpp
+++ b/src/NimBLEService.cpp
@@ -159,7 +159,7 @@ bool NimBLEService::start() {
             // Nimble requires the last characteristic to have it's uuid = 0 to indicate the end
             // of the characteristics for the service. We create 1 extra and set it to null
             // for this purpose.
-            pChr_a = new ble_gatt_chr_def[numChrs + 1];
+            pChr_a = new ble_gatt_chr_def[numChrs + 1]{};
             int i = 0;
             for(auto chr_it = m_chrVec.begin(); chr_it != m_chrVec.end(); ++chr_it) {
                 if((*chr_it)->m_removed > 0) {

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -10,6 +10,8 @@
 #include "sdkconfig.h"
 #include "nimconfig_rename.h"
 
+#include <ctime>
+
 #if defined(CONFIG_BT_ENABLED)
 
 // Allows cpp wrapper to select the correct include paths when using esp-idf


### PR DESCRIPTION
Updates the interface to use a typedef'd std::function for the advertise callback, which is backwards compatible but also allows std::bind and lambda functions.