### PR TITLE
Feature/client from server connection

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -402,7 +402,7 @@ void NimBLEAdvertising::setScanResponseData(NimBLEAdvertisementData& advertiseme
  * @param [in] dirAddr The address of a peer to directly advertise to.
  * @return True if advertising started successfully.
  */
-bool NimBLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(NimBLEAdvertising *pAdv), NimBLEAddress* dirAddr) {
+bool NimBLEAdvertising::start(uint32_t duration, advCompleteCB_t advCompleteCB, NimBLEAddress* dirAddr) {
     NIMBLE_LOGD(LOG_TAG, ">> Advertising start: customAdvData: %d, customScanResponseData: %d",
                 m_customAdvData, m_customScanResponseData);
 

--- a/src/NimBLEAdvertising.h
+++ b/src/NimBLEAdvertising.h
@@ -33,6 +33,7 @@
 #include "NimBLEUUID.h"
 #include "NimBLEAddress.h"
 
+#include <functional>
 #include <vector>
 
 /* COMPATIBILITY - DO NOT USE */
@@ -44,6 +45,10 @@
 #define ESP_BLE_ADV_FLAG_NON_LIMIT_DISC     (0x00 )
  /* ************************* */
 
+
+class NimBLEAdvertising;
+
+typedef std::function<void(NimBLEAdvertising*)> advCompleteCB_t;
 
 /**
  * @brief Advertisement data set by the programmer to be published by the %BLE server.
@@ -92,7 +97,7 @@ public:
     void addServiceUUID(const NimBLEUUID &serviceUUID);
     void addServiceUUID(const char* serviceUUID);
     void removeServiceUUID(const NimBLEUUID &serviceUUID);
-    bool start(uint32_t duration = 0, void (*advCompleteCB)(NimBLEAdvertising *pAdv) = nullptr, NimBLEAddress* dirAddr = nullptr);
+    bool start(uint32_t duration = 0, advCompleteCB_t advCompleteCB = nullptr, NimBLEAddress* dirAddr = nullptr);
     bool stop();
     void setAppearance(uint16_t appearance);
     void setName(const std::string &name);
@@ -129,7 +134,7 @@ private:
     bool                    m_customScanResponseData;
     bool                    m_scanResp;
     bool                    m_advDataSet;
-    void                    (*m_advCompCB)(NimBLEAdvertising *pAdv);
+    advCompleteCB_t         m_advCompCB{nullptr};
     uint8_t                 m_slaveItvl[4];
     uint32_t                m_duration;
     std::vector<uint8_t>    m_svcData16;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -552,6 +552,11 @@ uint16_t NimBLEClient::getConnId() {
 } // getConnId
 
 
+void NimBLEClient::setConnId(uint16_t conn_id) {
+    m_conn_id = conn_id;
+    m_connEstablished = true;
+} // setConnId
+
 /**
  * @brief Retrieve the address of the peer.
  */

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,6 +61,7 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
+    void                                        setConnId(uint16_t conn_id);
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint32_t timeout);

--- a/src/nimconfig.h
+++ b/src/nimconfig.h
@@ -10,6 +10,8 @@
 #include "sdkconfig.h"
 #include "nimconfig_rename.h"
 
+#include <ctime>
+
 #if defined(CONFIG_BT_ENABLED)
 
 // Allows cpp wrapper to select the correct include paths when using esp-idf


### PR DESCRIPTION
This PR adds a `setConnId` to the `NimBLEClient` class, to allow it to be used with existing server connections.