### PR TITLE
feat(NimBLEClient): allow connection id / established flag to be set via public API.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -589,7 +589,7 @@ bool NimBLEClient::setConnection(NimBLEConnInfo &connInfo) {
  * @note If the client is already connected to a peer, this will return false.
  * @note This will look up the peer address using the connection id.
  */
-bool NimBLEClient::setConnnection(uint16_t conn_id) {
+bool NimBLEClient::setConnection(uint16_t conn_id) {
     if (isConnected() || m_connEstablished) {
         NIMBLE_LOGE(LOG_TAG, "Already connected");
         return false;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -564,7 +564,7 @@ uint16_t NimBLEClient::getConnId() {
  *       enables the GATT Server to read the name of the device that has
  *       connected to it.
  */
-bool NimBLEClient::setConnection(const NimBLEConnInfo &connInfo) {
+bool NimBLEClient::setConnection(NimBLEConnInfo &connInfo) {
     if (isConnected() || m_connEstablished) {
         NIMBLE_LOGE(LOG_TAG, "Already connected");
         return false;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -578,7 +578,7 @@ bool NimBLEClient::setConnection(NimBLEConnInfo &connInfo) {
 } // setConnection
 
 /**
- * @brief Set the connection id for this client.
+ * @brief Set the connection information for this client.
  * @param [in] conn_id The connection id.
  * @note Sets the connection established flag to true.
  * @note This is designed to be used when a connection is made outside of the
@@ -589,7 +589,7 @@ bool NimBLEClient::setConnection(NimBLEConnInfo &connInfo) {
  * @note If the client is already connected to a peer, this will return false.
  * @note This will look up the peer address using the connection id.
  */
-bool NimBLEClient::setConnId(uint16_t conn_id) {
+bool NimBLEClient::setConnnection(uint16_t conn_id) {
     if (isConnected() || m_connEstablished) {
         NIMBLE_LOGE(LOG_TAG, "Already connected");
         return false;
@@ -619,7 +619,7 @@ bool NimBLEClient::setConnId(uint16_t conn_id) {
 } // setConnId
 
 /**
- * @brief Set the connection id for this client.
+ * @brief Set the connection information for this client.
  * @param [in] conn_id The connection id.
  * @param [in] peerAddress The address of the peer that this client is
  * @note Sets the connection established flag to true.
@@ -630,7 +630,7 @@ bool NimBLEClient::setConnId(uint16_t conn_id) {
  *       connected to it.
  * @note If the client is already connected to a peer, this will return false.
  */
-bool NimBLEClient::setConnId(uint16_t conn_id, const NimBLEAddress &peerAddress) {
+bool NimBLEClient::setConnection(uint16_t conn_id, const NimBLEAddress &peerAddress) {
     if (isConnected() || m_connEstablished) {
         NIMBLE_LOGE(LOG_TAG, "Already connected");
         return false;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -553,6 +553,31 @@ uint16_t NimBLEClient::getConnId() {
 
 
 /**
+ * @brief Set the connection information for this client.
+ * @param [in] connInfo The connection information.
+ * @return True on success.
+ * @note Sets the connection established flag to true.
+ * @note If the client is already connected to a peer, this will return false.
+ * @note This is designed to be used when a connection is made outside of the
+ *       NimBLEClient class, such as when a connection is made by the
+ *       NimBLEServer class and the client is passed the connection id. This use
+ *       enables the GATT Server to read the name of the device that has
+ *       connected to it.
+ */
+bool NimBLEClient::setConnection(const NimBLEConnInfo &connInfo) {
+    if (isConnected() || m_connEstablished) {
+        NIMBLE_LOGE(LOG_TAG, "Already connected");
+        return false;
+    }
+
+    m_peerAddress = connInfo.getAddress();
+    m_conn_id = connInfo.getConnHandle();
+    m_connEstablished = true;
+
+    return true;
+} // setConnection
+
+/**
  * @brief Set the connection id for this client.
  * @param [in] conn_id The connection id.
  * @note Sets the connection established flag to true.

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -551,6 +551,17 @@ uint16_t NimBLEClient::getConnId() {
     return m_conn_id;
 } // getConnId
 
+/**
+ * @brief Clear the connection information for this client.
+ * @note This is designed to be used to reset the connection information after
+ *       calling setConnection(), and should not be used to disconnect from a
+ *       peer. To disconnect from a peer, use disconnect().
+ */
+void NimBLEClient::clearConnection() {
+    m_conn_id = BLE_HS_CONN_HANDLE_NONE;
+    m_connEstablished = false;
+    m_peerAddress = NimBLEAddress();
+} // clearConnection
 
 /**
  * @brief Set the connection information for this client.

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -553,6 +553,21 @@ uint16_t NimBLEClient::getConnId() {
 
 
 /**
+ * @brief Set the connection id for this client.
+ * @param [in] conn_id The connection id.
+ * @note Sets the connection established flag to true.
+ * @note This is designed to be used when a connection is made outside of the
+ *       NimBLEClient class, such as when a connection is made by the
+ *       NimBLEServer class and the client is passed the connection id. This use
+ *       enables the GATT Server to read the name of the device that has
+ *       connected to it.
+ */
+void NimBLEClient::setConnId(uint16_t conn_id) {
+    m_conn_id = conn_id;
+    m_connEstablished = true;
+} // setConnId
+
+/**
  * @brief Retrieve the address of the peer.
  */
 NimBLEAddress NimBLEClient::getPeerAddress() {

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -579,7 +579,7 @@ bool NimBLEClient::setConnId(uint16_t conn_id) {
     }
 
     // ensure the address is valid
-    auto address = connInfo.getIdAddress();
+    auto address = connInfo.getAddress();
     if(address == NimBLEAddress("")) {
         NIMBLE_LOGE(LOG_TAG, "Invalid peer address;(NULL)");
         return false;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -590,11 +590,6 @@ bool NimBLEClient::setConnection(NimBLEConnInfo &connInfo) {
  * @note This will look up the peer address using the connection id.
  */
 bool NimBLEClient::setConnection(uint16_t conn_id) {
-    if (isConnected() || m_connEstablished) {
-        NIMBLE_LOGE(LOG_TAG, "Already connected");
-        return false;
-    }
-
     // we weren't provided the peer address, look it up using ble_gap_conn_find
     NimBLEConnInfo connInfo;
     int rc = ble_gap_conn_find(m_conn_id, &connInfo.m_desc);
@@ -603,52 +598,8 @@ bool NimBLEClient::setConnection(uint16_t conn_id) {
         return false;
     }
 
-    // ensure the address is valid
-    auto address = connInfo.getAddress();
-    if(address == NimBLEAddress("")) {
-        NIMBLE_LOGE(LOG_TAG, "Invalid peer address;(NULL)");
-        return false;
-    }
-
-    // we're good, so update the state
-    m_conn_id = conn_id;
-    m_connEstablished = true;
-    m_peerAddress = address;
-
-    return true;
-} // setConnId
-
-/**
- * @brief Set the connection information for this client.
- * @param [in] conn_id The connection id.
- * @param [in] peerAddress The address of the peer that this client is
- * @note Sets the connection established flag to true.
- * @note This is designed to be used when a connection is made outside of the
- *       NimBLEClient class, such as when a connection is made by the
- *       NimBLEServer class and the client is passed the connection id. This use
- *       enables the GATT Server to read the name of the device that has
- *       connected to it.
- * @note If the client is already connected to a peer, this will return false.
- */
-bool NimBLEClient::setConnection(uint16_t conn_id, const NimBLEAddress &peerAddress) {
-    if (isConnected() || m_connEstablished) {
-        NIMBLE_LOGE(LOG_TAG, "Already connected");
-        return false;
-    }
-
-    // ensure the address is valid
-    if(peerAddress == NimBLEAddress("")) {
-        NIMBLE_LOGE(LOG_TAG, "Invalid peer address;(NULL)");
-        return false;
-    }
-
-    // we're good, so update the state
-    m_conn_id = conn_id;
-    m_connEstablished = true;
-    m_peerAddress = peerAddress;
-
-    return true;
-} // setConnId
+    return setConnection(connInfo);
+} // setConnection
 
 /**
  * @brief Retrieve the address of the peer.

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,6 +61,7 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
+    void                                        setConnId(uint16_t conn_id);
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint32_t timeout);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,6 +61,7 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
+    void                                        clearConnection();
     bool                                        setConnection(NimBLEConnInfo &conn_info);
     bool                                        setConnection(uint16_t conn_id);
     uint16_t                                    getMTU();

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,7 +61,7 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
-    bool                                        setConnection(const NimBLEConnInfo &conn_info);
+    bool                                        setConnection(NimBLEConnInfo &conn_info);
     bool                                        setConnId(uint16_t conn_id);
     bool                                        setConnId(uint16_t conn_id, const NimBLEAddress &peerAddress);
     uint16_t                                    getMTU();

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -63,7 +63,6 @@ public:
     uint16_t                                    getConnId();
     bool                                        setConnection(NimBLEConnInfo &conn_info);
     bool                                        setConnection(uint16_t conn_id);
-    bool                                        setConnection(uint16_t conn_id, const NimBLEAddress &peerAddress);
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint32_t timeout);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,7 +61,8 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
-    void                                        setConnId(uint16_t conn_id);
+    bool                                        setConnId(uint16_t conn_id);
+    bool                                        setConnId(uint16_t conn_id, const NimBLEAddress &peerAddress);
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint32_t timeout);

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -61,6 +61,7 @@ public:
                                                                    bool deleteCallbacks = true);
     std::string                                 toString();
     uint16_t                                    getConnId();
+    bool                                        setConnection(const NimBLEConnInfo &conn_info);
     bool                                        setConnId(uint16_t conn_id);
     bool                                        setConnId(uint16_t conn_id, const NimBLEAddress &peerAddress);
     uint16_t                                    getMTU();

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -62,8 +62,8 @@ public:
     std::string                                 toString();
     uint16_t                                    getConnId();
     bool                                        setConnection(NimBLEConnInfo &conn_info);
-    bool                                        setConnId(uint16_t conn_id);
-    bool                                        setConnId(uint16_t conn_id, const NimBLEAddress &peerAddress);
+    bool                                        setConnection(uint16_t conn_id);
+    bool                                        setConnection(uint16_t conn_id, const NimBLEAddress &peerAddress);
     uint16_t                                    getMTU();
     bool                                        secureConnection();
     void                                        setConnectTimeout(uint32_t timeout);


### PR DESCRIPTION
This PR replaces #152 

Main use case is to allow an easy mechanism for GATT Servers to read the name of connected clients by passing their connection info to the Client class.

Example (from [espp::BleGattServer](https://github.com/esp-cpp/espp/blob/main/components/ble_gatt_server/include/ble_gatt_server.hpp#L513)):

```c++
  std::string get_connected_device_name(NimBLEConnInfo &conn_info) {
    if (!server_) {
      logger_.error("Server not created");
      return {};
    }
    if (!client_) {
      logger_.error("Client not created");
      return {};
    }

    // since this connection is handled by the server, we won't manually
    // connect, and instead inform the client that we are already connected
    // using this conn handle
    client_->clearConnection(); // make sure any previous connection state is cleared
    client_->setConnection(conn_info);

    // could alternatively use:
    // client_->clearConnection();
    // client_->setConnection(conn_info.getConnHandle(), conn_info.getAddress());

    // refresh the services
    client_->getServices(true);
    // now get Generic Access Service
    auto gas = client_->getService(NimBLEUUID("1800"));
    if (!gas) {
      logger_.error("Failed to get Generic Access Service");
      return {};
    }
    // now get the Device Name characteristic
    auto name_char = gas->getCharacteristic(NimBLEUUID("2A00"));
    if (!name_char) {
      logger_.error("Failed to get Device Name characteristic");
      return {};
    }
    // make sure we can read it
    if (!name_char->canRead()) {
      logger_.error("Failed to read Device Name characteristic");
      return {};
    }
    // and read it
    return name_char->readValue();
  }
```