### PR TITLE
feat(NimBLEDevice): deleteAllBonds() return code

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -567,10 +567,11 @@ int NimBLEDevice::getNumBonds() {
 
 /**
  * @brief Deletes all bonding information.
+ * @returns 0 on success, non-zero on failure.
  */
 /*STATIC*/
-void NimBLEDevice::deleteAllBonds() {
-    ble_store_clear();
+int NimBLEDevice::deleteAllBonds() {
+    return ble_store_clear();
 }
 
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -567,11 +567,16 @@ int NimBLEDevice::getNumBonds() {
 
 /**
  * @brief Deletes all bonding information.
- * @returns 0 on success, non-zero on failure.
+ * @returns true on success, false on failure.
  */
 /*STATIC*/
-int NimBLEDevice::deleteAllBonds() {
-    return ble_store_clear();
+bool NimBLEDevice::deleteAllBonds() {
+    int rc = ble_store_clear();
+    if (rc != 0) {
+        NIMBLE_LOGE(LOG_TAG, "Failed to delete all bonds; rc=%d", rc);
+        return false;
+    }
+    return true;
 }
 
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -172,7 +172,7 @@ public:
     static bool             deleteBond(const NimBLEAddress &address);
     static int              getNumBonds();
     static bool             isBonded(const NimBLEAddress &address);
-    static void             deleteAllBonds();
+    static int              deleteAllBonds();
     static NimBLEAddress    getBondedAddress(int index);
 #endif
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -172,7 +172,7 @@ public:
     static bool             deleteBond(const NimBLEAddress &address);
     static int              getNumBonds();
     static bool             isBonded(const NimBLEAddress &address);
-    static int              deleteAllBonds();
+    static bool             deleteAllBonds();
     static NimBLEAddress    getBondedAddress(int index);
 #endif
 


### PR DESCRIPTION
Allows caller to know whether `NimBLEDevice::deleteAllBonds()` (and thus the underlying `ble_store_clear()` call) succeeded or failed.