### PR TITLE
Fix failure to reconnect to device when bonded.

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -139,6 +139,15 @@ uint8_t NimBLEAddress::getType() const {
 
 
 /**
+ * @brief Determine if this address is a Resolvable Private Address.
+ * @return True if the address is a RPA.
+ */
+bool NimBLEAddress::isRpa() const {
+    return (m_addrType && ((m_address[5] & 0xc0) == 0x40));
+} // isRpa
+
+
+/**
  * @brief Convert a BLE address to a string.
  *
  * A string representation of an address is in the format:

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -43,6 +43,7 @@ public:
     NimBLEAddress(uint8_t address[6], uint8_t type = BLE_ADDR_PUBLIC);
     NimBLEAddress(const std::string &stringAddress, uint8_t type = BLE_ADDR_PUBLIC);
     NimBLEAddress(const uint64_t &address, uint8_t type = BLE_ADDR_PUBLIC);
+    bool            isRpa() const;
     bool            equals(const NimBLEAddress &otherAddress) const;
     const uint8_t*  getNative() const;
     std::string     toString() const;

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -1189,6 +1189,19 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event *event, void *arg) {
             break;
         } //BLE_GAP_EVENT_ENC_CHANGE
 
+        case BLE_GAP_EVENT_IDENTITY_RESOLVED: {
+            NimBLEConnInfo peerInfo;
+            rc = ble_gap_conn_find(event->identity_resolved.conn_handle, &peerInfo.m_desc);
+            if (rc != 0) {
+                NIMBLE_LOGE(LOG_TAG, "Connection info not found");
+                rc = 0;
+                break;
+            }
+
+            pClient->m_pClientCallbacks->onIdentity(peerInfo);
+            break;
+        } // BLE_GAP_EVENT_IDENTITY_RESOLVED
+
         case BLE_GAP_EVENT_MTU: {
             if(pClient->m_conn_id != event->mtu.conn_handle){
                 return 0;
@@ -1325,6 +1338,10 @@ void NimBLEClientCallbacks::onPassKeyEntry(const NimBLEConnInfo& connInfo){
 void NimBLEClientCallbacks::onAuthenticationComplete(const NimBLEConnInfo& connInfo){
     NIMBLE_LOGD("NimBLEClientCallbacks", "onAuthenticationComplete: default");
 }
+
+void NimBLEClientCallbacks::onIdentity(const NimBLEConnInfo& connInfo){
+    NIMBLE_LOGD("NimBLEClientCallbacks", "onIdentity: default");
+} // onIdentity
 
 void NimBLEClientCallbacks::onConfirmPIN(const NimBLEConnInfo& connInfo, uint32_t pin){
     NIMBLE_LOGD("NimBLEClientCallbacks", "onConfirmPIN: default: true");

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -164,6 +164,12 @@ public:
      * @param [in] pin The pin to compare with the server.
      */
     virtual void onConfirmPIN(const NimBLEConnInfo& connInfo, uint32_t pin);
+
+    /**
+     * @brief Called when the peer identity address is resolved.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     */
+    virtual void onIdentity(const NimBLEConnInfo& connInfo);
 };
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_CENTRAL */

--- a/src/NimBLEConnInfo.h
+++ b/src/NimBLEConnInfo.h
@@ -53,6 +53,6 @@ public:
     bool             isAuthenticated() const { return (m_desc.sec_state.authenticated == 1); }
 
     /** @brief Gets the key size used to encrypt the connection */
-    uint8_t          getSecKeySize()       { return m_desc.sec_state.key_size; }
+    uint8_t          getSecKeySize() const   { return m_desc.sec_state.key_size; }
 };
 #endif

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -691,6 +691,7 @@ bool NimBLEDevice::whiteListAdd(const NimBLEAddress & address) {
     int rc = ble_gap_wl_set(&wlVec[0], wlVec.size());
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Failed adding to whitelist rc=%d", rc);
+        m_whiteList.pop_back();
         return false;
     }
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -908,8 +908,8 @@ void NimBLEDevice::init(const std::string &deviceName) {
         ble_hs_cfg.sm_bonding = 0;
         ble_hs_cfg.sm_mitm = 0;
         ble_hs_cfg.sm_sc = 1;
-        ble_hs_cfg.sm_our_key_dist = 1;
-        ble_hs_cfg.sm_their_key_dist = 3;
+        ble_hs_cfg.sm_our_key_dist = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
+        ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
 
         ble_hs_cfg.store_status_cb = ble_store_util_status_rr; /*TODO: Implement handler for this*/
 

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -528,6 +528,16 @@ int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
             return 0;
         } // BLE_GAP_EVENT_ENC_CHANGE
 
+        case BLE_GAP_EVENT_IDENTITY_RESOLVED: {
+            rc = ble_gap_conn_find(event->identity_resolved.conn_handle, &peerInfo.m_desc);
+            if(rc != 0) {
+                return BLE_ATT_ERR_INVALID_HANDLE;
+            }
+
+            pServer->m_pServerCallbacks->onIdentity(peerInfo);
+            return 0;
+        } // BLE_GAP_EVENT_IDENTITY_RESOLVED
+
         case BLE_GAP_EVENT_PASSKEY_ACTION: {
             struct ble_sm_io pkey = {0,0};
 
@@ -863,6 +873,10 @@ void NimBLEServerCallbacks::onConfirmPIN(const NimBLEConnInfo& connInfo, uint32_
     NIMBLE_LOGD("NimBLEServerCallbacks", "onConfirmPIN: default: true");
     NimBLEDevice::injectConfirmPIN(connInfo, true);
 } // onConfirmPIN
+
+void NimBLEServerCallbacks::onIdentity(const NimBLEConnInfo& connInfo){
+    NIMBLE_LOGD("NimBLEServerCallbacks", "onIdentity: default");
+} // onIdentity
 
 void NimBLEServerCallbacks::onAuthenticationComplete(const NimBLEConnInfo& connInfo){
     NIMBLE_LOGD("NimBLEServerCallbacks", "onAuthenticationComplete: default");

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -173,6 +173,12 @@ public:
      * about the peer connection parameters.
      */
     virtual void onAuthenticationComplete(const NimBLEConnInfo& connInfo);
+
+    /**
+     * @brief Called when the peer identity address is resolved.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     */
+    virtual void onIdentity(const NimBLEConnInfo& connInfo);
 }; // NimBLEServerCallbacks
 
 #endif /* CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL */


### PR DESCRIPTION
iOS devices specifically expect to receive the ID key of the bonded device even when RPA is not used. This sets the default value of the key distribution config to provide the ID key as well as the encryption key.

resolves #11 and #159 