### PR TITLE
Update CMakeLists.txt for ESP32H2 to compile with IDF as component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ idf_component_register(
     "esp32c2"
     "esp32c3"
     "esp32c6"
+    "esp32h2"
   INCLUDE_DIRS
     "src"
   SRCS


### PR DESCRIPTION
Small change to enable compilation of an IDF project with NimBLE as a component out of the box. I tested this library with ESP32H2 for 6 months using IDF versions 5.1.3 and 5.1.4, and it is working fine.