### PR TITLE
Remove assert for 0x2902, make a dummy descriptor instead.

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -87,9 +87,7 @@ NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const char* uuid, uint3
  */
 NimBLEDescriptor* NimBLECharacteristic::createDescriptor(const NimBLEUUID &uuid, uint32_t properties, uint16_t max_len) {
     NimBLEDescriptor* pDescriptor = nullptr;
-    if(uuid == NimBLEUUID(uint16_t(0x2902))) {
-        assert(0 && "0x2902 descriptors cannot be manually created");
-    } else if (uuid == NimBLEUUID(uint16_t(0x2904))) {
+    if (uuid == NimBLEUUID(uint16_t(0x2904))) {
         pDescriptor = new NimBLE2904(this);
     } else {
         pDescriptor = new NimBLEDescriptor(uuid, properties, max_len, this);

--- a/src/NimBLEDescriptor.cpp
+++ b/src/NimBLEDescriptor.cpp
@@ -55,7 +55,14 @@ NimBLEDescriptor::NimBLEDescriptor(NimBLEUUID uuid, uint16_t properties, uint16_
     m_pCharacteristic    = pCharacteristic;
     m_pCallbacks         = &defaultCallbacks;           // No initial callback.
     m_properties         = 0;
-    m_removed            = 0;
+
+    // Check if this is the client configuration descriptor and set to removed if true.
+    if (uuid == NimBLEUUID((uint16_t)0x2902)) {
+        NIMBLE_LOGW(LOG_TAG, "Manually created 2902 descriptor has no functionality; please remove.");
+        m_removed = 1;
+    } else {
+        m_removed = 0;
+    }
 
     if (properties & BLE_GATT_CHR_F_READ) {             // convert uint16_t properties to uint8_t
         m_properties |= BLE_ATT_F_READ;


### PR DESCRIPTION
Rather than asserting for a harmless situation, this will just create a dummy descriptor object, marked as removed, and print a warning.