### PR TITLE
Remove NimBLEUtils::checkConnParams.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -458,9 +458,6 @@ void NimBLEClient::setConnectionParams(uint16_t minInterval, uint16_t maxInterva
     // These are not used by NimBLE at this time - Must leave at defaults
     //m_pConnParams->min_ce_len = minConnTime;     // Minimum length of connection event in 0.625ms units
     //m_pConnParams->max_ce_len = maxConnTime;     // Maximum length of connection event in 0.625ms units
-
-    int rc = NimBLEUtils::checkConnParams(&m_pConnParams);
-    assert(rc == 0 && "Invalid Connection parameters");
 } // setConnectionParams
 
 

--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -16,45 +16,6 @@
 
 static const char* LOG_TAG = "NimBLEUtils";
 
-
-/**
- * @brief A function for checking validity of connection parameters.
- * @param [in] params A pointer to the structure containing the parameters to check.
- * @return valid == 0 or error code.
- */
-int NimBLEUtils::checkConnParams(ble_gap_conn_params* params) {
-    /* Check connection interval min */
-    if ((params->itvl_min < BLE_HCI_CONN_ITVL_MIN) ||
-        (params->itvl_min > BLE_HCI_CONN_ITVL_MAX)) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-    /* Check connection interval max */
-    if ((params->itvl_max < BLE_HCI_CONN_ITVL_MIN) ||
-        (params->itvl_max > BLE_HCI_CONN_ITVL_MAX) ||
-        (params->itvl_max < params->itvl_min)) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-
-    /* Check connection latency */
-    if (params->latency > BLE_HCI_CONN_LATENCY_MAX) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-
-    /* Check supervision timeout */
-    if ((params->supervision_timeout < BLE_HCI_CONN_SPVN_TIMEOUT_MIN) ||
-        (params->supervision_timeout > BLE_HCI_CONN_SPVN_TIMEOUT_MAX)) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-
-    /* Check connection event length */
-    if (params->min_ce_len > params->max_ce_len) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-
-    return 0;
-}
-
-
 /**
  * @brief Converts a return code from the NimBLE stack to a text string.
  * @param [in] rc The return code to convert.

--- a/src/NimBLEUtils.h
+++ b/src/NimBLEUtils.h
@@ -43,7 +43,6 @@ public:
     static char*                buildHexData(uint8_t* target, const uint8_t* source, uint8_t length);
     static const char*          advTypeToString(uint8_t advType);
     static const char*          returnCodeToString(int rc);
-    static int                  checkConnParams(ble_gap_conn_params* params);
 };
 
 


### PR DESCRIPTION
This function is not required as the stack will return an error code in the case of invalid params.