### PR TITLE
[BREAKING] Change NIMBLE_LOGC macro to use printf.

### DIFF
--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -500,7 +500,7 @@ bool NimBLEAdvertising::start(uint32_t duration, advCompleteCB_t advCompleteCB, 
                 if(nullptr == (m_advData.uuids16 = (ble_uuid16_t*)realloc((void*)m_advData.uuids16,
                                                    (m_advData.num_uuids16 + 1) * sizeof(ble_uuid16_t))))
                 {
-                    NIMBLE_LOGC(LOG_TAG, "Error, no mem");
+                    NIMBLE_LOGE(LOG_TAG, "Error, no mem");
                     return false;
                 }
                 memcpy((void*)&m_advData.uuids16[m_advData.num_uuids16],
@@ -519,7 +519,7 @@ bool NimBLEAdvertising::start(uint32_t duration, advCompleteCB_t advCompleteCB, 
                 if(nullptr == (m_advData.uuids32 = (ble_uuid32_t*)realloc((void*)m_advData.uuids32,
                                                    (m_advData.num_uuids32 + 1) * sizeof(ble_uuid32_t))))
                 {
-                    NIMBLE_LOGC(LOG_TAG, "Error, no mem");
+                    NIMBLE_LOGE(LOG_TAG, "Error, no mem");
                     return false;
                 }
                 memcpy((void*)&m_advData.uuids32[m_advData.num_uuids32],
@@ -538,7 +538,7 @@ bool NimBLEAdvertising::start(uint32_t duration, advCompleteCB_t advCompleteCB, 
                 if(nullptr == (m_advData.uuids128 = (ble_uuid128_t*)realloc((void*)m_advData.uuids128,
                               (m_advData.num_uuids128 + 1) * sizeof(ble_uuid128_t))))
                 {
-                    NIMBLE_LOGC(LOG_TAG, "Error, no mem");
+                    NIMBLE_LOGE(LOG_TAG, "Error, no mem");
                     return false;
                 }
                 memcpy((void*)&m_advData.uuids128[m_advData.num_uuids128],
@@ -772,7 +772,7 @@ int NimBLEAdvertising::handleGapEvent(struct ble_gap_event *event, void *arg) {
             case BLE_HS_EOS:
             case BLE_HS_ECONTROLLER:
             case BLE_HS_ENOTSYNCED:
-                NIMBLE_LOGC(LOG_TAG, "host reset, rc=%d", event->adv_complete.reason);
+                NIMBLE_LOGE(LOG_TAG, "host reset, rc=%d", event->adv_complete.reason);
                 NimBLEDevice::onReset(event->adv_complete.reason);
                 return 0;
             default:

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -111,7 +111,7 @@ NimBLEClient::~NimBLEClient() {
  */
 void NimBLEClient::dcTimerCb(ble_npl_event *event) {
  /*   NimBLEClient *pClient = (NimBLEClient*)event->arg;
-    NIMBLE_LOGC(LOG_TAG, "Timed out disconnecting from %s - resetting host",
+    NIMBLE_LOGE(LOG_TAG, "Timed out disconnecting from %s - resetting host",
                 std::string(pClient->getPeerAddress()).c_str());
  */
     ble_hs_sched_reset(BLE_HS_ECONTROLLER);
@@ -189,7 +189,7 @@ bool NimBLEClient::connect(const NimBLEAddress &address, bool deleteAttributes) 
     NIMBLE_LOGD(LOG_TAG, ">> connect(%s)", address.toString().c_str());
 
     if(!NimBLEDevice::m_synced) {
-        NIMBLE_LOGC(LOG_TAG, "Host reset, wait for sync.");
+        NIMBLE_LOGE(LOG_TAG, "Host reset, wait for sync.");
         return false;
     }
 
@@ -1002,7 +1002,7 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event *event, void *arg) {
                 case BLE_HS_ETIMEOUT_HCI:
                 case BLE_HS_ENOTSYNCED:
                 case BLE_HS_EOS:
-                    NIMBLE_LOGC(LOG_TAG, "Disconnect - host reset, rc=%d", rc);
+                    NIMBLE_LOGE(LOG_TAG, "Disconnect - host reset, rc=%d", rc);
                     NimBLEDevice::onReset(rc);
                     break;
                 default:

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -778,7 +778,7 @@ void NimBLEDevice::onReset(int reason)
 
     m_synced = false;
 
-    NIMBLE_LOGC(LOG_TAG, "Resetting state; reason=%d, %s", reason,
+    NIMBLE_LOGE(LOG_TAG, "Resetting state; reason=%d, %s", reason,
                         NimBLEUtils::returnCodeToString(reason));
 
 #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)

--- a/src/NimBLEExtAdvertising.cpp
+++ b/src/NimBLEExtAdvertising.cpp
@@ -341,7 +341,7 @@ int NimBLEExtAdvertising::handleGapEvent(struct ble_gap_event *event, void *arg)
                 case BLE_HS_EOS:
                 case BLE_HS_ECONTROLLER:
                 case BLE_HS_ENOTSYNCED:
-                    NIMBLE_LOGC(LOG_TAG, "host reset, rc = %d", event->adv_complete.reason);
+                    NIMBLE_LOGE(LOG_TAG, "host reset, rc = %d", event->adv_complete.reason);
                     NimBLEDevice::onReset(event->adv_complete.reason);
                     return 0;
                 default:

--- a/src/NimBLELog.h
+++ b/src/NimBLELog.h
@@ -14,6 +14,7 @@
 
 #if defined(CONFIG_NIMBLE_CPP_IDF) // using esp-idf
 #  include "esp_log.h"
+#  include "console/console.h"
 #  ifndef CONFIG_NIMBLE_CPP_LOG_LEVEL
 #    define CONFIG_NIMBLE_CPP_LOG_LEVEL 0
 #  endif
@@ -33,9 +34,6 @@
      NIMBLE_CPP_LOG_PRINT(ESP_LOG_WARN, tag, format, ##__VA_ARGS__)
 
 #  define NIMBLE_LOGE(tag, format, ...) \
-     NIMBLE_CPP_LOG_PRINT(ESP_LOG_ERROR, tag, format, ##__VA_ARGS__)
-
-#  define NIMBLE_LOGC(tag, format, ...) \
      NIMBLE_CPP_LOG_PRINT(ESP_LOG_ERROR, tag, format, ##__VA_ARGS__)
 
 #else // using Arduino
@@ -69,12 +67,13 @@
 
 #  if CONFIG_NIMBLE_CPP_LOG_LEVEL >= 1
 #    define NIMBLE_LOGE( tag, format, ... ) console_printf("E %s: " format "\n", tag, ##__VA_ARGS__)
-#    define NIMBLE_LOGC( tag, format, ... ) console_printf("CRIT %s: " format "\n", tag, ##__VA_ARGS__)
 #  else
 #    define NIMBLE_LOGE( tag, format, ... ) (void)tag
-#    define NIMBLE_LOGC( tag, format, ... ) (void)tag
 #  endif
 
 #endif /* CONFIG_NIMBLE_CPP_IDF */
+
+#define NIMBLE_LOGC( tag, format, ... ) console_printf("CRIT %s: " format "\n", tag, ##__VA_ARGS__)
+
 #endif /* CONFIG_BT_ENABLED */
 #endif /* MAIN_NIMBLELOG_H_ */

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -359,7 +359,7 @@ bool NimBLEScan::start(uint32_t duration, bool is_continue) {
         case BLE_HS_EOS:
         case BLE_HS_ECONTROLLER:
         case BLE_HS_ENOTSYNCED:
-            NIMBLE_LOGC(LOG_TAG, "Unable to scan - Host Reset");
+            NIMBLE_LOGE(LOG_TAG, "Unable to scan - Host Reset");
             break;
 
         default:

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -516,7 +516,7 @@ int NimBLEServer::handleGapEvent(struct ble_gap_event *event, void *arg) {
                 case BLE_HS_EOS:
                 case BLE_HS_ECONTROLLER:
                 case BLE_HS_ENOTSYNCED:
-                    NIMBLE_LOGC(LOG_TAG, "Disconnect - host reset, rc=%d", event->disconnect.reason);
+                    NIMBLE_LOGE(LOG_TAG, "Disconnect - host reset, rc=%d", event->disconnect.reason);
                     NimBLEDevice::onReset(event->disconnect.reason);
                     break;
                 default:


### PR DESCRIPTION
Replaces all use of NIMBLE_LOGC with NIMBLE_LOGE and redefines NIMBLE_LOGC to use printf. This allows NIMBLE_CPP_DEBUG_ASSERT messages to print event when log level filtering is set to none.