### PR TITLE
fix(NimBLEDevice): clear all before port_deinit to prevent crash

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -917,6 +917,36 @@ void NimBLEDevice::init(const std::string &deviceName) {
  */
 /* STATIC */
 void NimBLEDevice::deinit(bool clearAll) {
+    if(clearAll) {
+#if defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
+        if(NimBLEDevice::m_pServer != nullptr) {
+            delete NimBLEDevice::m_pServer;
+            NimBLEDevice::m_pServer = nullptr;
+        }
+#endif
+
+#if defined(CONFIG_BT_NIMBLE_ROLE_BROADCASTER)
+        if(NimBLEDevice::m_bleAdvertising != nullptr) {
+            delete NimBLEDevice::m_bleAdvertising;
+            NimBLEDevice::m_bleAdvertising = nullptr;
+        }
+#endif
+
+#if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
+        if(NimBLEDevice::m_pScan != nullptr) {
+            delete NimBLEDevice::m_pScan;
+            NimBLEDevice::m_pScan= nullptr;
+        }
+#endif
+
+#if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+        for(auto clt : m_pClients) {
+            deleteClient(clt);
+        }
+#endif
+        m_ignoreList.clear();
+    }
+
     int ret = nimble_port_stop();
     if (ret == 0) {
         nimble_port_deinit();
@@ -930,36 +960,6 @@ void NimBLEDevice::deinit(bool clearAll) {
 #endif
         initialized = false;
         m_synced = false;
-
-        if(clearAll) {
-#if defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
-            if(NimBLEDevice::m_pServer != nullptr) {
-                delete NimBLEDevice::m_pServer;
-                NimBLEDevice::m_pServer = nullptr;
-            }
-#endif
-
-#if defined(CONFIG_BT_NIMBLE_ROLE_BROADCASTER)
-            if(NimBLEDevice::m_bleAdvertising != nullptr) {
-                delete NimBLEDevice::m_bleAdvertising;
-                NimBLEDevice::m_bleAdvertising = nullptr;
-            }
-#endif
-
-#if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
-            if(NimBLEDevice::m_pScan != nullptr) {
-                delete NimBLEDevice::m_pScan;
-                NimBLEDevice::m_pScan= nullptr;
-            }
-#endif
-
-#if defined( CONFIG_BT_NIMBLE_ROLE_CENTRAL)
-            for(auto clt : m_pClients) {
-                deleteClient(clt);
-            }
-#endif
-            m_ignoreList.clear();
-        }
     }
 } // deinit
 


### PR DESCRIPTION
This is an upstream PR matching https://github.com/esp-cpp/esp-nimble-cpp/pull/3. Relevant info copied below:

## Description
<!--- Describe your changes in detail -->
Update `NimBLEDevice::deinit()` to run the `clearAll` block (if true) before calling `nimble_port_deinit()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found that running `NimBLEDevice::deinit(true)` if I had a client created (as in `espp::BleGattServer`) would lead to a crash as the `~NimBLEClient()` would call `ble_npl_callout_deinit()`, which would lead to a crash. Moving the `clearAll` block to before the `nimble_port_deinit()` call does not result in a crash for the same code.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running in a separate project which was crashing before this change.

See example output here: https://github.com/esp-cpp/espp/pull/325

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Small snippet of the coredump:
![CleanShot 2024-09-06 at 08 56 36](https://github.com/user-attachments/assets/6e65fd97-a9c9-4fbb-8984-acd2090ec7f2)
