### PR TITLE
fix: #200 Enable use of `data()`/`size()` before trying `c_str()`/`length()`

### DIFF
--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -224,25 +224,16 @@ class NimBLEAttValue {
     /**
      * @brief Template to set value to the value of <type\>val.
      * @param [in] s The <type\>value to set.
-     * @param [in] len The length of the value in bytes, defaults to string.length().
+     * @note This function is only availabe if the type T is not a pointer.
      */
     template <typename T>
-    bool setValue(const T& s, uint16_t len = 0) {
+    bool setValue(const T& s) requires (!std::is_pointer_v<T>) {
         if constexpr (Has_data_size<T>::value) {
-            if (len == 0) {
-                len = s.size();
-            }
-            return setValue(reinterpret_cast<const uint8_t*>(s.data()), len);
+            return setValue(reinterpret_cast<const uint8_t*>(s.data()), s.size());
         } else if constexpr (Has_c_str_length<T>::value) {
-            if (len == 0) {
-                len = s.length();
-            }
-            return setValue(reinterpret_cast<const uint8_t*>(s.c_str()), len);
+            return setValue(reinterpret_cast<const uint8_t*>(s.c_str()), s.length());
         } else {
-            if (len == 0) {
-                len = sizeof(s);
-            }
-            return setValue(reinterpret_cast<const uint8_t*>(&s[0]), len);
+            return setValue(reinterpret_cast<const uint8_t*>(&s[0]), sizeof(s));
         }
     }
 

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -234,7 +234,7 @@ class NimBLEAttValue {
         } else if constexpr (Has_c_str_length<T>::value) {
             return setValue(reinterpret_cast<const uint8_t*>(s.c_str()), s.length());
         } else {
-            return setValue(reinterpret_cast<const uint8_t*>(&s[0]), sizeof(s));
+            return setValue(reinterpret_cast<const uint8_t*>(&s), sizeof(s));
         }
     }
 

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -227,7 +227,7 @@ class NimBLEAttValue {
      * @note This function is only availabe if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if_t<!std::is_pointer_v<T>, bool>
+    std::enable_if<!std::is_pointer_v<T>, bool>::type
     setValue(const T& s) {
         if constexpr (Has_data_size<T>::value) {
             return setValue(reinterpret_cast<const uint8_t*>(s.data()), s.size());

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -227,7 +227,7 @@ class NimBLEAttValue {
      * @note This function is only availabe if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer_v<T>, bool>::type
+    std::enable_if<!std::is_pointer<T>::value, bool>::type
     setValue(const T& s) {
         if constexpr (Has_data_size<T>::value) {
             return setValue(reinterpret_cast<const uint8_t*>(s.data()), s.size());

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -46,6 +46,14 @@ template <typename T>
 struct Has_data_size<T, decltype(void(std::declval<T&>().data())), decltype(void(std::declval<T&>().size()))>
     : std::true_type {};
 
+/* Used to determine if the type passed to a template has a c_str() and length() method. */
+template <typename T, typename = void, typename = void>
+struct Has_c_str_length : std::false_type {};
+
+template <typename T>
+struct Has_c_str_length<T, decltype(void(std::declval<T&>().c_str())), decltype(void(std::declval<T&>().length()))>
+    : std::true_type {};
+
 /**
  * @brief A specialized container class to hold BLE attribute values.
  * @details This class is designed to be more memory efficient than using\n
@@ -216,39 +224,26 @@ class NimBLEAttValue {
     /**
      * @brief Template to set value to the value of <type\>val.
      * @param [in] s The <type\>value to set.
-     * @param [in] len The length of the value in bytes, defaults to sizeof(T).
-     * @details Only used for types without a `data()` method.
-     */
-    template <typename T>
-# ifdef _DOXYGEN_
-    bool
-# else
-    typename std::enable_if<!Has_data_size<T>::value, bool>::type
-# endif
-    setValue(const T& s, uint16_t len = 0) {
-        if (len == 0) {
-            len = sizeof(T);
-        }
-        return setValue(reinterpret_cast<const uint8_t*>(&s), len);
-    }
-
-    /**
-     * @brief Template to set value to the value of <type\>val.
-     * @param [in] s The <type\>value to set.
      * @param [in] len The length of the value in bytes, defaults to string.length().
-     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
-# ifdef _DOXYGEN_
-    bool
-# else
-    typename std::enable_if<Has_data_size<T>::value, bool>::type
-# endif
-    setValue(const T& s, uint16_t len = 0) {
-        if (len == 0) {
-            len = s.size();
+    bool setValue(const T& s, uint16_t len = 0) {
+        if constexpr (Has_data_size<T>::value) {
+            if (len == 0) {
+                len = s.size();
+            }
+            return setValue(reinterpret_cast<const uint8_t*>(s.data()), len);
+        } else if constexpr (Has_c_str_length<T>::value) {
+            if (len == 0) {
+                len = s.length();
+            }
+            return setValue(reinterpret_cast<const uint8_t*>(s.c_str()), len);
+        } else {
+            if (len == 0) {
+                len = sizeof(s);
+            }
+            return setValue(reinterpret_cast<const uint8_t*>(&s[0]), len);
         }
-        return setValue(reinterpret_cast<const uint8_t*>(s.data()), len);
     }
 
     /**

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -227,7 +227,7 @@ class NimBLEAttValue {
      * @note This function is only availabe if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer<T>::value, bool>::type
+    typename std::enable_if<!std::is_pointer<T>::value, bool>::type
     setValue(const T& s) {
         if constexpr (Has_data_size<T>::value) {
             return setValue(reinterpret_cast<const uint8_t*>(s.data()), s.size());

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -227,7 +227,8 @@ class NimBLEAttValue {
      * @note This function is only availabe if the type T is not a pointer.
      */
     template <typename T>
-    bool setValue(const T& s) requires (!std::is_pointer_v<T>) {
+    std::enable_if_t<!std::is_pointer_v<T>, bool>
+    setValue(const T& s) {
         if constexpr (Has_data_size<T>::value) {
             return setValue(reinterpret_cast<const uint8_t*>(s.data()), s.size());
         } else if constexpr (Has_c_str_length<T>::value) {

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -38,12 +38,12 @@
 #  error CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH cannot be less than 1; Range = 1 : 512
 # endif
 
-/* Used to determine if the type passed to a template has a c_str() and length() method. */
+/* Used to determine if the type passed to a template has a data() and size() method. */
 template <typename T, typename = void, typename = void>
-struct Has_c_str_len : std::false_type {};
+struct Has_data_size : std::false_type {};
 
 template <typename T>
-struct Has_c_str_len<T, decltype(void(std::declval<T&>().c_str())), decltype(void(std::declval<T&>().length()))>
+struct Has_data_size<T, decltype(void(std::declval<T&>().data())), decltype(void(std::declval<T&>().size()))>
     : std::true_type {};
 
 /**
@@ -217,13 +217,13 @@ class NimBLEAttValue {
      * @brief Template to set value to the value of <type\>val.
      * @param [in] s The <type\>value to set.
      * @param [in] len The length of the value in bytes, defaults to sizeof(T).
-     * @details Only used for types without a `c_str()` method.
+     * @details Only used for types without a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     bool
 # else
-    typename std::enable_if<!Has_c_str_len<T>::value, bool>::type
+    typename std::enable_if<!Has_data_size<T>::value, bool>::type
 # endif
     setValue(const T& s, uint16_t len = 0) {
         if (len == 0) {
@@ -236,19 +236,19 @@ class NimBLEAttValue {
      * @brief Template to set value to the value of <type\>val.
      * @param [in] s The <type\>value to set.
      * @param [in] len The length of the value in bytes, defaults to string.length().
-     * @details Only used if the <type\> has a `c_str()` method.
+     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     bool
 # else
-    typename std::enable_if<Has_c_str_len<T>::value, bool>::type
+    typename std::enable_if<Has_data_size<T>::value, bool>::type
 # endif
     setValue(const T& s, uint16_t len = 0) {
         if (len == 0) {
-            len = s.length();
+            len = s.size();
         }
-        return setValue(reinterpret_cast<const uint8_t*>(s.c_str()), len);
+        return setValue(reinterpret_cast<const uint8_t*>(s.data()), len);
     }
 
     /**

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -267,16 +267,6 @@ void NimBLECharacteristic::indicate(const uint8_t* value, size_t length, uint16_
 } // indicate
 
 /**
- * @brief Send an indication.
- * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
- * @param[in] conn_handle Connection handle to send an individual indication, or BLE_HS_CONN_HANDLE_NONE to send
- * the indication to all subscribed clients.
- */
-void NimBLECharacteristic::indicate(const std::vector<uint8_t>& value, uint16_t conn_handle) const {
-    sendValue(value.data(), value.size(), false, conn_handle);
-} // indicate
-
-/**
  * @brief Send a notification.
  * @param[in] conn_handle Connection handle to send an individual notification, or BLE_HS_CONN_HANDLE_NONE to send
  * the notification to all subscribed clients.
@@ -295,16 +285,6 @@ void NimBLECharacteristic::notify(uint16_t conn_handle) const {
 void NimBLECharacteristic::notify(const uint8_t* value, size_t length, uint16_t conn_handle) const {
     sendValue(value, length, true, conn_handle);
 } // indicate
-
-/**
- * @brief Send a notification.
- * @param[in] value A std::vector<uint8_t> containing the value to send as the notification value.
- * @param[in] conn_handle Connection handle to send an individual notification, or BLE_HS_CONN_HANDLE_NONE to send
- * the notification to all subscribed clients.
- */
-void NimBLECharacteristic::notify(const std::vector<uint8_t>& value, uint16_t conn_handle) const {
-    sendValue(value.data(), value.size(), true, conn_handle);
-} // notify
 
 /**
  * @brief Sends a notification or indication.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -77,7 +77,10 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     /*********************** Template Functions ************************/
 
     /**
-     * @brief Template to send a notification from a class type that has a data() and length() method.
+     * @brief Template to send a notification for classes which may have
+     *        data()/size() or c_str()/length() methods. Falls back to sending
+     *        the data by casting the first element of the array to a uint8_t
+     *        pointer and getting the length of the array using sizeof.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
      * @param[in] is_notification if true sends a notification, false sends an indication.
@@ -94,7 +97,10 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     }
 
     /**
-     * @brief Template to send an indication from a class type that has a data() and length() method.
+     * @brief Template to send an indication for classes which may have
+     *       data()/size() or c_str()/length() methods. Falls back to sending
+     *       the data by casting the first element of the array to a uint8_t
+     *       pointer and getting the length of the array using sizeof.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
      */

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -81,32 +81,32 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
      * @param[in] is_notification if true sends a notification, false sends an indication.
-     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
-# ifdef _DOXYGEN_
-    void
-# else
-    typename std::enable_if<Has_data_size<T>::value, void>::type
-# endif
-    notify(const T& value, bool is_notification = true) const {
-        notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
+    void notify(const T& value, bool is_notification = true) const {
+        if constexpr (Has_data_size<T>::value) {
+            notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
+        } else if constexpr (Has_c_str_length<T>::value) {
+            notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), is_notification);
+        } else {
+            notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
+        }
     }
 
     /**
      * @brief Template to send an indication from a class type that has a data() and length() method.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
-     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
-# ifdef _DOXYGEN_
-    void
-# else
-    typename std::enable_if<Has_data_size<T>::value, void>::type
-# endif
-    indicate(const T& value) const {
-        indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+    void indicate(const T& value) const {
+        if constexpr (Has_data_size<T>::value) {
+            indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+        } else if constexpr (Has_c_str_length<T>::value) {
+            indicate(reinterpret_cast<const uint8_t*>(value.c_str()), value.length());
+        } else {
+            indicate(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value));
+        }
     }
 
   private:

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -85,7 +85,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer<T>::value, void>::type
+    typename std::enable_if<!std::is_pointer<T>::value, void>::type
     notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
@@ -107,7 +107,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer<T>::value, void>::type
+    typename std::enable_if<!std::is_pointer<T>::value, void>::type
     indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -85,7 +85,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if_t<!std::is_pointer_v<T>, void>
+    std::enable_if<!std::is_pointer_v<T>, void>::type
     notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
@@ -107,7 +107,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if_t<!std::is_pointer_v<T>, void>
+    std::enable_if<!std::is_pointer_v<T>, void>::type
     indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -85,7 +85,8 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    void notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const requires (!std::is_pointer_v<T>) {
+    std::enable_if_t<!std::is_pointer_v<T>, void>
+    notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
         } else if constexpr (Has_c_str_length<T>::value) {
@@ -106,7 +107,8 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    void indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const requires (!std::is_pointer_v<T>) {
+    std::enable_if_t<!std::is_pointer_v<T>, void>
+    indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
         } else if constexpr (Has_c_str_length<T>::value) {

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -77,36 +77,36 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     /*********************** Template Functions ************************/
 
     /**
-     * @brief Template to send a notification from a class type that has a c_str() and length() method.
+     * @brief Template to send a notification from a class type that has a data() and length() method.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
      * @param[in] is_notification if true sends a notification, false sends an indication.
-     * @details Only used if the <type\> has a `c_str()` method.
+     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     void
 # else
-    typename std::enable_if<Has_c_str_len<T>::value, void>::type
+    typename std::enable_if<Has_data_size<T>::value, void>::type
 # endif
     notify(const T& value, bool is_notification = true) const {
-        notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), is_notification);
+        notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
     }
 
     /**
-     * @brief Template to send an indication from a class type that has a c_str() and length() method.
+     * @brief Template to send an indication from a class type that has a data() and length() method.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
-     * @details Only used if the <type\> has a `c_str()` method.
+     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     void
 # else
-    typename std::enable_if<Has_c_str_len<T>::value, void>::type
+    typename std::enable_if<Has_data_size<T>::value, void>::type
 # endif
     indicate(const T& value) const {
-        indicate(reinterpret_cast<const uint8_t*>(value.c_str()), value.length());
+        indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size());
     }
 
   private:

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -85,7 +85,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer_v<T>, void>::type
+    std::enable_if<!std::is_pointer<T>::value, void>::type
     notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
@@ -107,7 +107,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer_v<T>, void>::type
+    std::enable_if<!std::is_pointer<T>::value, void>::type
     indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const {
         if constexpr (Has_data_size<T>::value) {
             indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -92,7 +92,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
         } else if constexpr (Has_c_str_length<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), conn_handle);
         } else {
-            notify(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), conn_handle);
+            notify(reinterpret_cast<const uint8_t*>(&value), sizeof(value), conn_handle);
         }
     }
 
@@ -114,7 +114,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
         } else if constexpr (Has_c_str_length<T>::value) {
             indicate(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), conn_handle);
         } else {
-            indicate(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), conn_handle);
+            indicate(reinterpret_cast<const uint8_t*>(&value), sizeof(value), conn_handle);
         }
     }
 

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -56,10 +56,8 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     void        setCallbacks(NimBLECharacteristicCallbacks* pCallbacks);
     void        indicate(uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
     void        indicate(const uint8_t* value, size_t length, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
-    void        indicate(const std::vector<uint8_t>& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
     void        notify(uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
     void        notify(const uint8_t* value, size_t length, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
-    void        notify(const std::vector<uint8_t>& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const;
 
     NimBLEDescriptor* createDescriptor(const char* uuid,
                                        uint32_t    properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
@@ -83,16 +81,17 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      *        pointer and getting the length of the array using sizeof.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
-     * @param[in] is_notification if true sends a notification, false sends an indication.
+     * @param[in] conn_handle The connection handle to send the notification to.
+     * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    void notify(const T& value, bool is_notification = true) const {
+    void notify(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const requires (!std::is_pointer_v<T>) {
         if constexpr (Has_data_size<T>::value) {
-            notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
+            notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
         } else if constexpr (Has_c_str_length<T>::value) {
-            notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), is_notification);
+            notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), conn_handle);
         } else {
-            notify(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), is_notification);
+            notify(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), conn_handle);
         }
     }
 
@@ -103,15 +102,17 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
      *       pointer and getting the length of the array using sizeof.
      * @tparam T The a reference to a class containing the data to send.
      * @param[in] value The <type\>value to set.
+     * @param[in] conn_handle The connection handle to send the indication to.
+     * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    void indicate(const T& value) const {
+    void indicate(const T& value, uint16_t conn_handle = BLE_HS_CONN_HANDLE_NONE) const requires (!std::is_pointer_v<T>) {
         if constexpr (Has_data_size<T>::value) {
-            indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+            indicate(reinterpret_cast<const uint8_t*>(value.data()), value.size(), conn_handle);
         } else if constexpr (Has_c_str_length<T>::value) {
-            indicate(reinterpret_cast<const uint8_t*>(value.c_str()), value.length());
+            indicate(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), conn_handle);
         } else {
-            indicate(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value));
+            indicate(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), conn_handle);
         }
     }
 

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -89,7 +89,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
         } else if constexpr (Has_c_str_length<T>::value) {
             notify(reinterpret_cast<const uint8_t*>(value.c_str()), value.length(), is_notification);
         } else {
-            notify(reinterpret_cast<const uint8_t*>(value.data()), value.size(), is_notification);
+            notify(reinterpret_cast<const uint8_t*>(&value[0]), sizeof(value), is_notification);
         }
     }
 

--- a/src/NimBLEHIDDevice.cpp
+++ b/src/NimBLEHIDDevice.cpp
@@ -225,11 +225,11 @@ NimBLECharacteristic* NimBLEHIDDevice::batteryLevel() {
 	return m_batteryLevelCharacteristic;
 }
 
-/*
-
-BLECharacteristic*	 BLEHIDDevice::reportMap() {
+NimBLECharacteristic* NimBLEHIDDevice::reportMap() {
 	return m_reportMapCharacteristic;
 }
+
+/*
 
 BLECharacteristic*	 BLEHIDDevice::pnp() {
 	return m_pnpCharacteristic;

--- a/src/NimBLEHIDDevice.h
+++ b/src/NimBLEHIDDevice.h
@@ -60,7 +60,7 @@ public:
 	void 	setBatteryLevel(uint8_t level);
 
 
-	//NimBLECharacteristic* 	reportMap();
+	NimBLECharacteristic* 	reportMap();
 	NimBLECharacteristic* 	hidControl();
 	NimBLECharacteristic* 	inputReport(uint8_t reportID);
 	NimBLECharacteristic* 	outputReport(uint8_t reportID);

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -81,7 +81,7 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer_v<T>, bool>::type
+    std::enable_if<!std::is_pointer<T>::value, bool>::type
     writeValue(const T& v, bool response = false) const {
         if constexpr (Has_data_size<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -78,10 +78,11 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @brief Template to set the remote characteristic value to <type\>val.
      * @param [in] s The value to write.
      * @param [in] response True == request write response.
+     * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
     bool
-    writeValue(const T& v, bool response = false) const {
+    writeValue(const T& v, bool response = false) const requires (!std::is_pointer_v<T>) {
         if constexpr (Has_data_size<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);
         } else if constexpr (Has_c_str_length<T>::value) {

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -88,13 +88,13 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @brief Template to set the remote characteristic value to <type\>val.
      * @param [in] s The value to write.
      * @param [in] response True == request write response.
-     * @details Only used for non-arrays and types without a `c_str()` method.
+     * @details Only used for non-arrays and types without a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     bool
 # else
-    typename std::enable_if<!std::is_array<T>::value && !Has_c_str_len<T>::value, bool>::type
+    typename std::enable_if<!std::is_array<T>::value && !Has_data_size<T>::value, bool>::type
 # endif
     writeValue(const T& v, bool response = false) const {
         return writeValue(reinterpret_cast<const uint8_t*>(&v), sizeof(T), response);
@@ -104,16 +104,16 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @brief Template to set the remote characteristic value to <type\>val.
      * @param [in] s The value to write.
      * @param [in] response True == request write response.
-     * @details Only used if the <type\> has a `c_str()` method.
+     * @details Only used if the <type\> has a `data()` method.
      */
     template <typename T>
 # ifdef _DOXYGEN_
     bool
 # else
-    typename std::enable_if<Has_c_str_len<T>::value, bool>::type
+    typename std::enable_if<Has_data_size<T>::value, bool>::type
 # endif
     writeValue(const T& s, bool response = false) const {
-        return writeValue(reinterpret_cast<const uint8_t*>(s.c_str()), s.length(), response);
+        return writeValue(reinterpret_cast<const uint8_t*>(s.data()), s.size(), response);
     }
 
     /**

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -81,7 +81,7 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if<!std::is_pointer<T>::value, bool>::type
+    typename std::enable_if<!std::is_pointer<T>::value, bool>::type
     writeValue(const T& v, bool response = false) const {
         if constexpr (Has_data_size<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -88,7 +88,7 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
         } else if constexpr (Has_c_str_length<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.c_str()), v.length(), response);
         } else {
-            return writeValue(reinterpret_cast<const uint8_t*>(&v[0]), sizeof(v), response);
+            return writeValue(reinterpret_cast<const uint8_t*>(&v), sizeof(v), response);
         }
     }
 

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -81,7 +81,7 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    std::enable_if_t<!std::is_pointer_v<T>, bool>
+    std::enable_if<!std::is_pointer_v<T>, bool>::type
     writeValue(const T& v, bool response = false) const {
         if constexpr (Has_data_size<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -81,8 +81,8 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @note This function is only available if the type T is not a pointer.
      */
     template <typename T>
-    bool
-    writeValue(const T& v, bool response = false) const requires (!std::is_pointer_v<T>) {
+    std::enable_if_t<!std::is_pointer_v<T>, bool>
+    writeValue(const T& v, bool response = false) const {
         if constexpr (Has_data_size<T>::value) {
             return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);
         } else if constexpr (Has_c_str_length<T>::value) {

--- a/src/NimBLERemoteValueAttribute.h
+++ b/src/NimBLERemoteValueAttribute.h
@@ -64,16 +64,6 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
     bool writeValue(const uint8_t* data, size_t length, bool response = false) const;
 
     /**
-     * @brief Write a new value to the remote characteristic from a std::vector<uint8_t>.
-     * @param [in] vec A std::vector<uint8_t> value to write to the remote characteristic.
-     * @param [in] response Whether we require a response from the write.
-     * @return false if not connected or otherwise cannot perform write.
-     */
-    bool writeValue(const std::vector<uint8_t>& v, bool response = false) const {
-        return writeValue(&v[0], v.size(), response);
-    }
-
-    /**
      * @brief Write a new value to the remote characteristic from a const char*.
      * @param [in] str A character string to write to the remote characteristic.
      * @param [in] length (optional) The length of the character string, uses strlen if omitted.
@@ -88,32 +78,17 @@ class NimBLERemoteValueAttribute : public NimBLEAttribute {
      * @brief Template to set the remote characteristic value to <type\>val.
      * @param [in] s The value to write.
      * @param [in] response True == request write response.
-     * @details Only used for non-arrays and types without a `data()` method.
      */
     template <typename T>
-# ifdef _DOXYGEN_
     bool
-# else
-    typename std::enable_if<!std::is_array<T>::value && !Has_data_size<T>::value, bool>::type
-# endif
     writeValue(const T& v, bool response = false) const {
-        return writeValue(reinterpret_cast<const uint8_t*>(&v), sizeof(T), response);
-    }
-
-    /**
-     * @brief Template to set the remote characteristic value to <type\>val.
-     * @param [in] s The value to write.
-     * @param [in] response True == request write response.
-     * @details Only used if the <type\> has a `data()` method.
-     */
-    template <typename T>
-# ifdef _DOXYGEN_
-    bool
-# else
-    typename std::enable_if<Has_data_size<T>::value, bool>::type
-# endif
-    writeValue(const T& s, bool response = false) const {
-        return writeValue(reinterpret_cast<const uint8_t*>(s.data()), s.size(), response);
+        if constexpr (Has_data_size<T>::value) {
+            return writeValue(reinterpret_cast<const uint8_t*>(v.data()), v.size(), response);
+        } else if constexpr (Has_c_str_length<T>::value) {
+            return writeValue(reinterpret_cast<const uint8_t*>(v.c_str()), v.length(), response);
+        } else {
+            return writeValue(reinterpret_cast<const uint8_t*>(&v[0]), sizeof(v), response);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #200 

Replace test for `c_str()` and `length()` (which only matches a few stl containers), for the more general `data()` and `size()` check.

I tested with this example application and it now works properly: 

https://github.com/finger563/nimble-cpp-hid-issue-example/tree/main

Note: I realize I accidentally committed the update to `NimBLEHIDDevice` to expose the `reportMap` characteristic. Personally I think it's a good change, but LMK if you want to revert that.