### PR TITLE
Add initial esp32-P4 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ idf_component_register(
     "esp32c3"
     "esp32c6"
     "esp32h2"
+    "esp32p4"
   INCLUDE_DIRS
     "src"
   SRCS

--- a/Kconfig
+++ b/Kconfig
@@ -76,4 +76,51 @@ config NIMBLE_CPP_DEBUG_ASSERT_ENABLED
         Enabling this option will add debug asserts to the NimBLE CPP library.
         This will use approximately 1kB of flash memory.
 
+#
+# BT config
+#
+config BT_ENABLED
+    bool "Bluetooth"
+    default "y"
+    help
+        Select this option to enable Bluetooth and show the submenu with Bluetooth configuration choices.
+
+
+config BT_NIMBLE_ENABLED
+    bool "NimBLE - BLE only"
+    default "y"
+    help
+        This option is recommended for BLE only usecases to save on memory
+
+if IDF_TARGET_ESP32P4
+
+    config BT_NIMBLE_TRANSPORT_UART
+        bool "Enable Uart Transport"
+        default "n"
+
+    #
+    # Enable ESP Hosted BT
+    # Used as VHCI transport between BT Host and Controller
+    #
+    config ESP_ENABLE_BT
+        bool "Enable Hosted Bluetooth support"
+        default "y"
+        help
+            Enable Bluetooth Support via Hosted
+
+    choice ESP_WIFI_REMOTE_LIBRARY
+        prompt "Choose WiFi-remote implementation"
+        default ESP_WIFI_REMOTE_LIBRARY_HOSTED
+        help
+            Select type of WiFi Remote implementation
+
+            ESP-HOSTED is the default and most versatile option.
+            It's also possible to use EPPP, which uses PPPoS link between micros and NAPT, so it's slower
+            and less universal.
+
+        config ESP_WIFI_REMOTE_LIBRARY_HOSTED
+            bool "ESP-HOSTED"
+    endchoice
+endif
+
 endmenu

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,16 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/esp_hosted:
+    version: "*"
+    rules:
+      - if: "target in [esp32p4]"
+  espressif/esp_wifi_remote:
+    version: "*"
+    rules:
+      - if: "target in [esp32p4]"
+
+  ## Required IDF version
+  idf:
+    version: ">=5.3.0"
+    rules:
+      - if: "target in [esp32p4]"

--- a/src/NimBLEAdvertising.cpp
+++ b/src/NimBLEAdvertising.cpp
@@ -56,7 +56,9 @@ void NimBLEAdvertising::reset() {
     m_advData.name                   = (uint8_t *)name;
     m_advData.name_len               = strlen(name);
     m_advData.name_is_complete       = 1;
+#ifndef CONFIG_IDF_TARGET_ESP32P4
     m_advData.tx_pwr_lvl             = NimBLEDevice::getPower();
+#endif
     m_advData.flags                  = (BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP);
 
 #if !defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
@@ -1018,7 +1020,9 @@ void NimBLEAdvertisementData::addTxPower() {
     char cdata[3];
     cdata[0] = BLE_HS_ADV_TX_PWR_LVL_LEN + 1;
     cdata[1] = BLE_HS_ADV_TYPE_TX_PWR_LVL;
+#ifndef CONFIG_IDF_TARGET_ESP32P4
     cdata[2] = NimBLEDevice::getPower();
+#endif
     addData(cdata, 3);
 } // addTxPower
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -20,7 +20,9 @@
 
 #ifdef ESP_PLATFORM
 #  include "esp_err.h"
+#ifndef CONFIG_IDF_TARGET_ESP32P4
 #  include "esp_bt.h"
+#endif
 #  include "nvs_flash.h"
 #  if defined(CONFIG_NIMBLE_CPP_IDF)
 #    if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0) || CONFIG_BT_NIMBLE_LEGACY_VHCI_ENABLE)
@@ -360,6 +362,7 @@ NimBLEClient* NimBLEDevice::getDisconnectedClient() {
 #endif // #if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
 
 #ifdef ESP_PLATFORM
+#ifndef CONFIG_IDF_TARGET_ESP32P4
 /**
  * @brief Set the transmission power.
  * @param [in] powerLevel The power level to set, can be one of:
@@ -438,7 +441,7 @@ int NimBLEDevice::getPower(esp_ble_power_type_t powerType) {
             return BLE_HS_ADV_TX_PWR_LVL_AUTO;
     }
 } // getPower
-
+#endif
 #else
 
 void NimBLEDevice::setPower(int dbm) {

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -42,7 +42,9 @@ class NimBLEClient;
 #include "NimBLEAddress.h"
 
 #ifdef ESP_PLATFORM
+#ifndef CONFIG_IDF_TARGET_ESP32P4
 #  include "esp_bt.h"
+#endif
 #endif
 
 #include <string>
@@ -116,8 +118,10 @@ public:
 #endif
 
 #ifdef ESP_PLATFORM
+#ifndef CONFIG_IDF_TARGET_ESP32P4
     static void             setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
     static int              getPower(esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);
+#endif
     static void             setOwnAddrType(uint8_t own_addr_type, bool useNRPA=false);
     static void             setScanDuplicateCacheSize(uint16_t cacheSize);
     static void             setScanFilterMode(uint8_t type);


### PR DESCRIPTION
This commit adds initial support for esp32-p4 with esp32-c6 as a radio.
Configuration was tested on this dev board
https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/user_guide.html

Since it is using esp_hosted component and we cant use bluedroid API i had to disable get and set ble power API.
Maybe someone can find better solution, or maybe in the future we can re-enable those functions, when we have support for bluedroid.

Library tested with ble + wifi configuration and works fine.


PS i added some options to Kconfig to enable bluetooth by default, but there is no option to override espressif configs and to enable nimble by default, so it is last option which we have to do manually or with defconfig in our app