### PR TITLE
Fix NimBLEClient::secureConnection incorrectly failing with BLE_HS_EAGAIN

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -302,9 +302,8 @@ bool NimBLEClient::secureConnection() const {
     do {
         m_pTaskData = &taskData;
 
-        int rc = NimBLEDevice::startSecurity(m_connHandle);
-        if (rc != 0 && rc != BLE_HS_EALREADY) {
-            m_lastErr   = rc;
+        if (!NimBLEDevice::startSecurity(m_connHandle)) {
+            m_lastErr   = BLE_HS_ENOTCONN;
             m_pTaskData = nullptr;
             return false;
         }

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1127,7 +1127,7 @@ bool NimBLEDevice::startSecurity(uint16_t connHandle) {
         NIMBLE_LOGE(LOG_TAG, "ble_gap_security_initiate: rc=%d %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
 
-    return rc == 0;
+    return rc == 0 || rc == BLE_HS_EALREADY;
 } // startSecurity
 
 /**


### PR DESCRIPTION
Fixes #215 