### PR TITLE
Fix NimBLEUtils::dataToHexString returned string, must resize str.

### DIFF
--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -500,7 +500,7 @@ const char* NimBLEUtils::gapEventToString(uint8_t eventType) {
 std::string NimBLEUtils::dataToHexString(const uint8_t* source, uint8_t length) {
     constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
     std::string    str{};
-    str.resize(length * 2);
+    str.resize(length << 1);
 
     for (uint8_t i = 0; i < length; i++) {
         str[2 * i]     = hexmap[(source[i] & 0xF0) >> 4];

--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -500,7 +500,7 @@ const char* NimBLEUtils::gapEventToString(uint8_t eventType) {
 std::string NimBLEUtils::dataToHexString(const uint8_t* source, uint8_t length) {
     constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
     std::string    str{};
-    str.reserve(length * 2 + 1);
+    str.resize(length * 2);
 
     for (uint8_t i = 0; i < length; i++) {
         str[2 * i]     = hexmap[(source[i] & 0xF0) >> 4];


### PR DESCRIPTION
Commit 84f4d4f897963559dbb92ca73d1b68402b914c94 has broken NimBLEUtils::dataToHexString(). Manufacturing data is no longer visible when printing NimBLEAdvertisedDevice::toString().
Before
`I [  7210][main.cpp:198] BLE adv (-81 db, phy 1 0) Name: SHIELD, Address: 53:6f:93:26:6e:e7, manufacturer data: , serviceUUID: 0x3456, txPower: -15`

After
`I [  7238][main.cpp:198] BLE adv (-81 db, phy 1 0) Name: SHIELD, Address: 53:6f:93:26:6e:e7, manufacturer data: ffff65636635323533326465643734323730, serviceUUID: 0x3456, txPower: -15`