### PR TITLE
Add asynchronous client connection secure

### DIFF
--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -65,7 +65,7 @@ class NimBLEClient {
     bool           setConnection(uint16_t connHandle);
     uint16_t       getMTU() const;
     bool           exchangeMTU();
-    bool           secureConnection() const;
+    bool           secureConnection(bool async = false) const;
     void           setConnectTimeout(uint32_t timeout);
     bool           setDataLen(uint16_t txOctets);
     bool           discoverAttributes();
@@ -131,6 +131,7 @@ class NimBLEClient {
     NimBLEClientCallbacks*            m_pClientCallbacks;
     uint16_t                          m_connHandle;
     uint8_t                           m_terminateFailCount;
+    mutable uint8_t                   m_asyncSecureAttempt;
     Config                            m_config;
 
 # if CONFIG_BT_NIMBLE_EXT_ADV

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1136,14 +1136,17 @@ uint32_t NimBLEDevice::getSecurityPasskey() {
 /**
  * @brief Start the connection securing and authorization for this connection.
  * @param connHandle The connection handle of the peer device.
- * @returns NimBLE stack return code, 0 = success.
+ * @param rcPtr Optional pointer to pass the return code to the caller.
+ * @returns True if successfully started, success = 0 or BLE_HS_EALREADY.
  */
-bool NimBLEDevice::startSecurity(uint16_t connHandle) {
+bool NimBLEDevice::startSecurity(uint16_t connHandle, int* rcPtr) {
     int rc = ble_gap_security_initiate(connHandle);
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "ble_gap_security_initiate: rc=%d %s", rc, NimBLEUtils::returnCodeToString(rc));
     }
-
+    if (rcPtr) {
+        *rcPtr = rc;
+    }
     return rc == 0 || rc == BLE_HS_EALREADY;
 } // startSecurity
 

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -129,7 +129,7 @@ class NimBLEDevice {
     static void          setSecurityRespKey(uint8_t respKey);
     static void          setSecurityPasskey(uint32_t passKey);
     static uint32_t      getSecurityPasskey();
-    static bool          startSecurity(uint16_t connHandle);
+    static bool          startSecurity(uint16_t connHandle, int* rcPtr = nullptr);
     static bool          setMTU(uint16_t mtu);
     static uint16_t      getMTU();
     static void          onReset(int reason);


### PR DESCRIPTION
* Adds parameter `rcPtr` to `NimBLEDevice::startSecurity`, default value works as the original method.
* * `rcPtr`: if not nullptr, will allow caller to obtain the internal return code.
* Adds parameter `async` to `NimBLEClient::secureConnection`, default value works as the original method.
* * `async`; if true, will send the secure command and return immediately with a true value for successfully sending the command, else false.