### PR TITLE
Refactor client connection establishment and client deletion.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -176,11 +176,6 @@ bool NimBLEClient::connect(const NimBLEAddress& address, bool deleteAttributes, 
         return false;
     }
 
-    if (NimBLEDevice::isConnectionInProgress()) {
-        NIMBLE_LOGE(LOG_TAG, "Connection already in progress");
-        return false;
-    }
-
     const ble_addr_t* peerAddr = address.getBase();
     if (ble_gap_conn_find_by_addr(peerAddr, NULL) == 0) {
         NIMBLE_LOGE(LOG_TAG, "A connection to %s already exists", address.toString().c_str());
@@ -201,9 +196,6 @@ bool NimBLEClient::connect(const NimBLEAddress& address, bool deleteAttributes, 
     int rc                = 0;
     m_config.asyncConnect = asyncConnect;
     m_config.exchangeMTU  = exchangeMTU;
-
-    // Set the connection in progress flag to prevent a scan from starting while connecting.
-    NimBLEDevice::setConnectionInProgress(true);
 
     do {
 # if CONFIG_BT_NIMBLE_EXT_ADV
@@ -258,7 +250,6 @@ bool NimBLEClient::connect(const NimBLEAddress& address, bool deleteAttributes, 
 
     if (rc != 0) {
         m_lastErr = rc;
-        NimBLEDevice::setConnectionInProgress(false);
         return false;
     }
 
@@ -985,7 +976,6 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
                 return 0;
             }
 
-            NimBLEDevice::setConnectionInProgress(false);
             rc = event->connect.status;
             if (rc == 0) {
                 pClient->m_connHandle = event->connect.conn_handle;

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -51,7 +51,8 @@ class NimBLEClient {
     bool connect(const NimBLEAddress& address, bool deleteAttributes = true, bool asyncConnect = false, bool exchangeMTU = true);
     bool           connect(bool deleteAttributes = true, bool asyncConnect = false, bool exchangeMTU = true);
     bool           disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
-    bool           cancelConnect();
+    bool           cancelConnect() const;
+    void           setSelfDelete(bool deleteOnDisconnect, bool deleteOnConnectFail);
     NimBLEAddress  getPeerAddress() const;
     bool           setPeerAddress(const NimBLEAddress& address);
     int            getRssi() const;
@@ -95,6 +96,17 @@ class NimBLEClient {
     void setConnectPhy(uint8_t mask);
 # endif
 
+    struct Config {
+        uint8_t deleteCallbacks : 1;     // Delete the callback object when the client is deleted.
+        uint8_t deleteOnDisconnect : 1;  // Delete the client when disconnected.
+        uint8_t deleteOnConnectFail : 1; // Delete the client when a connection attempt fails.
+        uint8_t asyncConnect : 1;        // Connect asynchronously.
+        uint8_t exchangeMTU : 1;         // Exchange MTU after connection.
+    };
+
+    Config getConfig() const;
+    void   setConfig(Config config);
+
   private:
     NimBLEClient(const NimBLEAddress& peerAddress);
     ~NimBLEClient();
@@ -117,10 +129,8 @@ class NimBLEClient {
     NimBLEClientCallbacks*            m_pClientCallbacks;
     uint16_t                          m_connHandle;
     uint8_t                           m_terminateFailCount;
-    bool                              m_deleteCallbacks;
-    bool                              m_connEstablished;
-    bool                              m_asyncConnect;
-    bool                              m_exchangeMTU;
+    Config                            m_config;
+
 # if CONFIG_BT_NIMBLE_EXT_ADV
     uint8_t m_phyMask;
 # endif

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -101,10 +101,6 @@ std::vector<NimBLEAddress> NimBLEDevice::m_ignoreList{};
 std::vector<NimBLEAddress> NimBLEDevice::m_whiteList{};
 uint8_t                    NimBLEDevice::m_ownAddrType{BLE_OWN_ADDR_PUBLIC};
 
-# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
-bool NimBLEDevice::m_connectionInProgress{false};
-# endif
-
 # ifdef ESP_PLATFORM
 #  ifdef CONFIG_BTDM_BLE_SCAN_DUPL
 uint16_t NimBLEDevice::m_scanDuplicateSize{CONFIG_BTDM_SCAN_DUPL_CACHE_SIZE};
@@ -1237,23 +1233,6 @@ bool NimBLEDevice::setCustomGapHandler(gap_event_handler handler) {
 
     return rc == 0;
 } // setCustomGapHandler
-
-/**
- * @brief Set the connection in progress flag.
- * @param [in] inProgress The connection in progress flag.
- * @details This is used to prevent a scan from starting while a connection is in progress.
- */
-void NimBLEDevice::setConnectionInProgress(bool inProgress) {
-    m_connectionInProgress = inProgress;
-} // setConnectionInProgress
-
-/**
- * @brief Check if a connection is in progress.
- * @return True if a connection is in progress.
- */
-bool NimBLEDevice::isConnectionInProgress() {
-    return m_connectionInProgress;
-} // isConnectionInProgress
 
 /**
  * @brief Return a string representation of the address of this device.

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -184,8 +184,6 @@ class NimBLEDevice {
     static bool          isBonded(const NimBLEAddress& address);
     static bool          deleteAllBonds();
     static NimBLEAddress getBondedAddress(int index);
-    static void          setConnectionInProgress(bool inProgress);
-    static bool          isConnectionInProgress();
 # endif
 
   private:
@@ -196,10 +194,6 @@ class NimBLEDevice {
     static ble_gap_event_listener     m_listener;
     static uint8_t                    m_ownAddrType;
     static std::vector<NimBLEAddress> m_whiteList;
-
-# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL) || defined(CONFIG_BT_NIMBLE_ROLE_PERIPHERAL)
-    static bool m_connectionInProgress;
-# endif
 
 # if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
     static NimBLEScan* m_pScan;

--- a/src/NimBLERemoteCharacteristic.cpp
+++ b/src/NimBLERemoteCharacteristic.cpp
@@ -69,6 +69,12 @@ int NimBLERemoteCharacteristic::descriptorDiscCB(
     const auto        pChr       = (NimBLERemoteCharacteristic*)pTaskData->m_pInstance;
     const NimBLEUUID* uuidFilter = filter->uuid;
 
+    if (error->status == BLE_HS_ENOTCONN) {
+        NIMBLE_LOGE(LOG_TAG, "<< Descriptor Discovery; Not connected");
+        NimBLEUtils::taskRelease(*pTaskData, error->status);
+        return error->status;
+    }
+
     if (pChr->getHandle() != chr_val_handle) {
         rc = BLE_HS_EDONE; // descriptor not for this characteristic
     }

--- a/src/NimBLERemoteService.cpp
+++ b/src/NimBLERemoteService.cpp
@@ -148,6 +148,13 @@ int NimBLERemoteService::characteristicDiscCB(uint16_t              conn_handle,
     auto       pTaskData = (NimBLETaskData*)arg;
     const auto pSvc      = (NimBLERemoteService*)pTaskData->m_pInstance;
 
+
+    if (error->status == BLE_HS_ENOTCONN) {
+        NIMBLE_LOGE(LOG_TAG, "<< Characteristic Discovery; Not connected");
+        NimBLEUtils::taskRelease(*pTaskData, error->status);
+        return error->status;
+    }
+
     // Make sure the discovery is for this device
     if (pSvc->getClient()->getConnHandle() != conn_handle) {
         return 0;

--- a/src/NimBLERemoteValueAttribute.cpp
+++ b/src/NimBLERemoteValueAttribute.cpp
@@ -91,6 +91,12 @@ int NimBLERemoteValueAttribute::onWriteCB(uint16_t conn_handle, const ble_gatt_e
     auto       pTaskData = static_cast<NimBLETaskData*>(arg);
     const auto pAtt      = static_cast<NimBLERemoteValueAttribute*>(pTaskData->m_pInstance);
 
+    if (error->status == BLE_HS_ENOTCONN) {
+        NIMBLE_LOGE(LOG_TAG, "<< Write complete; Not connected");
+        NimBLEUtils::taskRelease(*pTaskData, error->status);
+        return error->status;
+    }
+
     if (pAtt->getClient()->getConnHandle() != conn_handle) {
         return 0;
     }
@@ -169,6 +175,12 @@ Done:
 int NimBLERemoteValueAttribute::onReadCB(uint16_t conn_handle, const ble_gatt_error* error, ble_gatt_attr* attr, void* arg) {
     auto       pTaskData = static_cast<NimBLETaskData*>(arg);
     const auto pAtt      = static_cast<NimBLERemoteValueAttribute*>(pTaskData->m_pInstance);
+
+    if (error->status == BLE_HS_ENOTCONN) {
+        NIMBLE_LOGE(LOG_TAG, "<< Read complete; Not connected");
+        NimBLEUtils::taskRelease(*pTaskData, error->status);
+        return error->status;
+    }
 
     if (pAtt->getClient()->getConnHandle() != conn_handle) {
         return 0;

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -291,7 +291,7 @@ bool NimBLEScan::isScanning() {
 bool NimBLEScan::start(uint32_t duration, bool is_continue) {
     NIMBLE_LOGD(LOG_TAG, ">> start: duration=%" PRIu32, duration);
 
-    if (NimBLEDevice::isConnectionInProgress()) {
+    if (ble_gap_conn_active()) {
         NIMBLE_LOGE(LOG_TAG, "Connection in progress, cannot start scan");
         return false;
     }

--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -143,7 +143,7 @@ const char* NimBLEUtils::returnCodeToString(int rc) {
         case BLE_HS_ENOTSUP:
             return "Operation disabled at compile time";
         case BLE_HS_EAPP:
-            return "Application error";
+            return "Operation canceled by app";
         case BLE_HS_EBADDATA:
             return "Invalid command from peer";
         case BLE_HS_EOS:


### PR DESCRIPTION
* Removes the connection established flag as it should not be necessary.
* Deleting the client instance from the `onDisconnect` callback is now supported.
* `NimBLEDevice::deleteClient` no longer blocks tasks
* Adds a new `Config` struct to `NimBLEClient` to efficiently set single bit config settings.
* Adds `NimBLEClient::setSelfDelete` that takes the bool parameters `deleteOnDisconnect` and `deleteOnConnectFail`
  This will configure the client to delete itself when disconnected or the connection attempt fails.
* Adds `NimBLEClient::setConfig` and `NimBLEClient::getConfig` which takes or returns a `NimBLEClient::Config` object respectively.

* Reword `BLE_HS_EAPP` error string to be more accurate.
