### PR TITLE
[BREAKING] - Remove ignore list.

### DIFF
--- a/examples/Advanced/NimBLE_Client/main/main.cpp
+++ b/examples/Advanced/NimBLE_Client/main/main.cpp
@@ -343,9 +343,6 @@ void app_main (void){
     /** Optional: set the transmit power, default is -3db */
     NimBLEDevice::setPower(ESP_PWR_LVL_P9); /** 12db */
 
-    /** Optional: set any devices you don't want to get advertisments from */
-    // NimBLEDevice::addIgnored(NimBLEAddress ("aa:bb:cc:dd:ee:ff"));
-
     /** create new scan */
     NimBLEScan* pScan = NimBLEDevice::getScan();
 

--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -946,8 +946,6 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
             NIMBLE_LOGD(LOG_TAG, "disconnect; reason=%d, %s", rc, NimBLEUtils::returnCodeToString(rc));
 
             pClient->m_terminateFailCount = 0;
-            NimBLEDevice::removeIgnored(pClient->m_peerAddress);
-
             // Don't call the disconnect callback if we are waiting for a connection to complete and it fails
             if (rc != (BLE_HS_ERR_HCI_BASE + BLE_ERR_CONN_ESTABLISHMENT) || pClient->m_config.asyncConnect) {
                 pClient->m_pClientCallbacks->onDisconnect(pClient, rc);
@@ -985,10 +983,6 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
                         break;
                     }
                 }
-
-                // In the case of a multi-connecting device we ignore this device when
-                // scanning since we are already connected to it
-                NimBLEDevice::addIgnored(pClient->m_peerAddress);
             } else {
                 pClient->m_connHandle = BLE_HS_CONN_HANDLE_NONE;
                 if (!pClient->m_config.asyncConnect) {

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -97,7 +97,6 @@ bool                       NimBLEDevice::m_initialized{false};
 uint32_t                   NimBLEDevice::m_passkey{123456};
 bool                       NimBLEDevice::m_synced{false};
 ble_gap_event_listener     NimBLEDevice::m_listener{};
-std::vector<NimBLEAddress> NimBLEDevice::m_ignoreList{};
 std::vector<NimBLEAddress> NimBLEDevice::m_whiteList{};
 uint8_t                    NimBLEDevice::m_ownAddrType{BLE_OWN_ADDR_PUBLIC};
 
@@ -928,7 +927,6 @@ bool NimBLEDevice::deinit(bool clearAll) {
             deleteClient(clt);
         }
 # endif
-        m_ignoreList.clear();
     }
 
     return rc == 0;
@@ -1147,48 +1145,6 @@ bool NimBLEDevice::injectConfirmPasskey(const NimBLEConnInfo& peerInfo, bool acc
     int       rc = ble_sm_inject_io(peerInfo.getConnHandle(), &pkey);
     NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_NUMCMP; ble_sm_inject_io result: %d", rc);
     return rc == 0;
-}
-
-/* -------------------------------------------------------------------------- */
-/*                                 IGNORE LIST                                */
-/* -------------------------------------------------------------------------- */
-
-/**
- * @brief Check if the device address is on our ignore list.
- * @param [in] address The address to look for.
- * @return True if ignoring.
- */
-bool NimBLEDevice::isIgnored(const NimBLEAddress& address) {
-    for (const auto& addr : m_ignoreList) {
-        if (addr == address) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
- * @brief Add a device to the ignore list.
- * @param [in] address The address of the device we want to ignore.
- */
-void NimBLEDevice::addIgnored(const NimBLEAddress& address) {
-    if (!isIgnored(address)) {
-        m_ignoreList.push_back(address);
-    }
-}
-
-/**
- * @brief Remove a device from the ignore list.
- * @param [in] address The address of the device we want to remove from the list.
- */
-void NimBLEDevice::removeIgnored(const NimBLEAddress& address) {
-    for (auto it = m_ignoreList.begin(); it < m_ignoreList.end(); ++it) {
-        if (*it == address) {
-            m_ignoreList.erase(it);
-            std::vector<NimBLEAddress>(m_ignoreList).swap(m_ignoreList);
-        }
-    }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/NimBLEDevice.h
+++ b/src/NimBLEDevice.h
@@ -132,9 +132,6 @@ class NimBLEDevice {
     static bool          startSecurity(uint16_t connHandle);
     static bool          setMTU(uint16_t mtu);
     static uint16_t      getMTU();
-    static bool          isIgnored(const NimBLEAddress& address);
-    static void          addIgnored(const NimBLEAddress& address);
-    static void          removeIgnored(const NimBLEAddress& address);
     static void          onReset(int reason);
     static void          onSync(void);
     static void          host_task(void* param);
@@ -189,7 +186,6 @@ class NimBLEDevice {
   private:
     static bool                       m_synced;
     static bool                       m_initialized;
-    static std::vector<NimBLEAddress> m_ignoreList;
     static uint32_t                   m_passkey;
     static ble_gap_event_listener     m_listener;
     static uint8_t                    m_ownAddrType;

--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -66,12 +66,14 @@ int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
 # endif
             NimBLEAddress advertisedAddress(disc.addr);
 
-            // stop processing if we don't want to see it or are already connected
-            if (NimBLEDevice::isIgnored(advertisedAddress)) {
-                NIMBLE_LOGI(LOG_TAG, "Ignoring device: address: %s", advertisedAddress.toString().c_str());
+# ifdef CONFIG_BT_NIMBLE_ROLE_CENTRAL
+            // stop processing if already connected
+            NimBLEClient* pClient = NimBLEDevice::getClientByPeerAddress(advertisedAddress);
+            if (pClient != nullptr && pClient->isConnected()) {
+                NIMBLE_LOGI(LOG_TAG, "Ignoring device: address: %s, already connected", advertisedAddress.toString().c_str());
                 return 0;
             }
-
+# endif
             NimBLEAdvertisedDevice* advertisedDevice = nullptr;
 
             // If we've seen this device before get a pointer to it from the vector


### PR DESCRIPTION
This removes the ignore list feature as it can be implemented by the application if desired. The scan will now ignore any device we are connected to already by checking for any connected client with the same peer address.