### PR TITLE
[BREAKING] Refactor NimBLEBeacon

### DIFF
--- a/src/NimBLEBeacon.cpp
+++ b/src/NimBLEBeacon.cpp
@@ -1,5 +1,5 @@
 /*
- * NimBLEBeacon2.cpp
+ * NimBLEBeacon.cpp
  *
  *  Created: on March 15 2020
  *      Author H2zero
@@ -11,41 +11,25 @@
  *  Created on: Jan 4, 2018
  *      Author: kolban
  */
+
 #include "nimconfig.h"
-#if defined(CONFIG_BT_ENABLED)
+#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_BROADCASTER)
 
-#include <string.h>
-#include <algorithm>
-#include "NimBLEBeacon.h"
-#include "NimBLELog.h"
+# include "NimBLEBeacon.h"
+# include "NimBLEUUID.h"
+# include "NimBLELog.h"
 
-#define ENDIAN_CHANGE_U16(x) ((((x)&0xFF00)>>8) + (((x)&0xFF)<<8))
+# define ENDIAN_CHANGE_U16(x) ((((x) & 0xFF00) >> 8) + (((x) & 0xFF) << 8))
 
 static const char* LOG_TAG = "NimBLEBeacon";
-
-
-/**
- * @brief Construct a default beacon object.
- */
-NimBLEBeacon::NimBLEBeacon() {
-    m_beaconData.manufacturerId = 0x4c00;
-    m_beaconData.subType        = 0x02;
-    m_beaconData.subTypeLength  = 0x15;
-    m_beaconData.major          = 0;
-    m_beaconData.minor          = 0;
-    m_beaconData.signalPower    = 0;
-    memset(m_beaconData.proximityUUID, 0, sizeof(m_beaconData.proximityUUID));
-} // NimBLEBeacon
-
 
 /**
  * @brief Retrieve the data that is being advertised.
  * @return The advertised data.
  */
-std::string NimBLEBeacon::getData() {
-    return std::string((char*) &m_beaconData, sizeof(m_beaconData));
+const NimBLEBeacon::BeaconData& NimBLEBeacon::getData() {
+    return m_beaconData;
 } // getData
-
 
 /**
  * @brief Get the major value being advertised.
@@ -53,8 +37,7 @@ std::string NimBLEBeacon::getData() {
  */
 uint16_t NimBLEBeacon::getMajor() {
     return m_beaconData.major;
-}
-
+} // getMajor
 
 /**
  * @brief Get the manufacturer ID being advertised.
@@ -62,8 +45,7 @@ uint16_t NimBLEBeacon::getMajor() {
  */
 uint16_t NimBLEBeacon::getManufacturerId() {
     return m_beaconData.manufacturerId;
-}
-
+} // getManufacturerId
 
 /**
  * @brief Get the minor value being advertised.
@@ -71,8 +53,7 @@ uint16_t NimBLEBeacon::getManufacturerId() {
  */
 uint16_t NimBLEBeacon::getMinor() {
     return m_beaconData.minor;
-}
-
+} // getMinor
 
 /**
  * @brief Get the proximity UUID being advertised.
@@ -80,8 +61,7 @@ uint16_t NimBLEBeacon::getMinor() {
  */
 NimBLEUUID NimBLEBeacon::getProximityUUID() {
     return NimBLEUUID(m_beaconData.proximityUUID, 16).reverseByteOrder();
-}
-
+} // getProximityUUID
 
 /**
  * @brief Get the signal power being advertised.
@@ -89,22 +69,28 @@ NimBLEUUID NimBLEBeacon::getProximityUUID() {
  */
 int8_t NimBLEBeacon::getSignalPower() {
     return m_beaconData.signalPower;
-}
-
+} // getSignalPower
 
 /**
- * @brief Set the raw data for the beacon record.
- * @param [in] data The raw beacon data.
+ * @brief Set the beacon data.
+ * @param [in] data A pointer to the raw data that the beacon should advertise.
+ * @param [in] length The length of the data.
  */
-void NimBLEBeacon::setData(const std::string &data) {
-    if (data.length() != sizeof(m_beaconData)) {
-        NIMBLE_LOGE(LOG_TAG, "Unable to set the data ... length passed in was %d and expected %d",
-                                                        data.length(), sizeof(m_beaconData));
+void NimBLEBeacon::setData(const uint8_t* data, uint8_t length) {
+    if (length != sizeof(BeaconData)) {
+        NIMBLE_LOGE(LOG_TAG, "Data length must be %d bytes, sent: %d", sizeof(BeaconData), length);
         return;
     }
-    memcpy(&m_beaconData, data.data(), sizeof(m_beaconData));
+    memcpy(&m_beaconData, data, length);
 } // setData
 
+/**
+ * @brief Set the beacon data.
+ * @param [in] data The data that the beacon should advertise.
+ */
+void NimBLEBeacon::setData(const NimBLEBeacon::BeaconData& data) {
+    m_beaconData = data;
+} // setData
 
 /**
  * @brief Set the major value.
@@ -114,7 +100,6 @@ void NimBLEBeacon::setMajor(uint16_t major) {
     m_beaconData.major = ENDIAN_CHANGE_U16(major);
 } // setMajor
 
-
 /**
  * @brief Set the manufacturer ID.
  * @param [in] manufacturerId The manufacturer ID value.
@@ -122,7 +107,6 @@ void NimBLEBeacon::setMajor(uint16_t major) {
 void NimBLEBeacon::setManufacturerId(uint16_t manufacturerId) {
     m_beaconData.manufacturerId = ENDIAN_CHANGE_U16(manufacturerId);
 } // setManufacturerId
-
 
 /**
  * @brief Set the minor value.
@@ -132,17 +116,16 @@ void NimBLEBeacon::setMinor(uint16_t minor) {
     m_beaconData.minor = ENDIAN_CHANGE_U16(minor);
 } // setMinor
 
-
 /**
  * @brief Set the proximity UUID.
  * @param [in] uuid The proximity UUID.
  */
-void NimBLEBeacon::setProximityUUID(const NimBLEUUID &uuid) {
+void NimBLEBeacon::setProximityUUID(const NimBLEUUID& uuid) {
     NimBLEUUID temp_uuid = uuid;
     temp_uuid.to128();
-    std::reverse_copy(temp_uuid.getValue(), temp_uuid.getValue() + 16, m_beaconData.proximityUUID);
+    temp_uuid.reverseByteOrder();
+    memcpy(m_beaconData.proximityUUID, temp_uuid.getValue(), 16);
 } // setProximityUUID
-
 
 /**
  * @brief Set the signal power.
@@ -152,4 +135,4 @@ void NimBLEBeacon::setSignalPower(int8_t signalPower) {
     m_beaconData.signalPower = signalPower;
 } // setSignalPower
 
-#endif
+#endif // CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_BROADCASTER

--- a/src/NimBLEBeacon.h
+++ b/src/NimBLEBeacon.h
@@ -1,51 +1,61 @@
 /*
- * NimBLEBeacon2.h
+ * NimBLEBeacon.h
  *
  *  Created: on March 15 2020
  *      Author H2zero
  *
  * Originally:
  *
- * BLEBeacon2.h
+ * BLEBeacon.h
  *
  *  Created on: Jan 4, 2018
  *      Author: kolban
  */
 
-#ifndef MAIN_NIMBLEBEACON_H_
-#define MAIN_NIMBLEBEACON_H_
+#ifndef NIMBLE_CPP_BEACON_H_
+#define NIMBLE_CPP_BEACON_H_
 
-#include "NimBLEUUID.h"
+#include "nimconfig.h"
+#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BT_NIMBLE_ROLE_BROADCASTER)
+
+class NimBLEUUID;
+
+# include <cstdint>
+
 /**
  * @brief Representation of a beacon.
  * See:
  * * https://en.wikipedia.org/wiki/IBeacon
  */
 class NimBLEBeacon {
-private:
-    struct {
-        uint16_t manufacturerId;
-        uint8_t  subType;
-        uint8_t  subTypeLength;
-        uint8_t  proximityUUID[16];
-        uint16_t major;
-        uint16_t minor;
-        int8_t   signalPower;
-    } __attribute__((packed)) m_beaconData;
-public:
-    NimBLEBeacon();
-    std::string getData();
-    uint16_t    getMajor();
-    uint16_t    getMinor();
-    uint16_t    getManufacturerId();
-    NimBLEUUID     getProximityUUID();
-    int8_t      getSignalPower();
-    void        setData(const std::string &data);
-    void        setMajor(uint16_t major);
-    void        setMinor(uint16_t minor);
-    void        setManufacturerId(uint16_t manufacturerId);
-    void        setProximityUUID(const NimBLEUUID &uuid);
-    void        setSignalPower(int8_t signalPower);
+  public:
+    struct BeaconData {
+        uint16_t manufacturerId{0x4c00};
+        uint8_t  subType{0x02};
+        uint8_t  subTypeLength{0x15};
+        uint8_t  proximityUUID[16]{};
+        uint16_t major{};
+        uint16_t minor{};
+        int8_t   signalPower{};
+    } __attribute__((packed));
+
+    const BeaconData& getData();
+    uint16_t          getMajor();
+    uint16_t          getMinor();
+    uint16_t          getManufacturerId();
+    NimBLEUUID        getProximityUUID();
+    int8_t            getSignalPower();
+    void              setData(const uint8_t* data, uint8_t length);
+    void              setData(const BeaconData& data);
+    void              setMajor(uint16_t major);
+    void              setMinor(uint16_t minor);
+    void              setManufacturerId(uint16_t manufacturerId);
+    void              setProximityUUID(const NimBLEUUID& uuid);
+    void              setSignalPower(int8_t signalPower);
+
+  private:
+    BeaconData m_beaconData;
 }; // NimBLEBeacon
 
-#endif /* MAIN_NIMBLEBEACON_H_ */
+#endif // NIMBLE_CPP_BEACON_H_
+#endif // CONFIG_BT_ENABLED && CONFIG_BT_NIMBLE_ROLE_PERIPHERAL


### PR DESCRIPTION
* General code cleanup
* The internal data struct type `BeaconData` is now public and can be used by the application.
* `NimBLEBeacon::setData` now takes `const NimBLEBeacon::BeaconData&` instead of `std::string`.
* Added overload for `NimBLEBeacon::setData` that takes a pointer to raw `uint8_t` data and length`.
* `NimBLEBeacon::getData` now returns `const NimBLEBeacon::BeaconData&` instead of `std::string`.