### PR TITLE
Add support for creating a NimBLEClient from a NimBLEServer peer.

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -537,62 +537,6 @@ uint16_t NimBLEClient::getConnHandle() const {
 } // getConnHandle
 
 /**
- * @brief Clear the connection information for this client.
- * @note This is designed to be used to reset the connection information after
- * calling setConnection(), and should not be used to disconnect from a peer.
- * To disconnect from a peer, use disconnect().
- */
-void NimBLEClient::clearConnection() {
-    m_connHandle  = BLE_HS_CONN_HANDLE_NONE;
-    m_peerAddress = NimBLEAddress{};
-} // clearConnection
-
-/**
- * @brief Set the connection information for this client.
- * @param [in] connInfo The connection information.
- * @return True on success.
- * @note Sets the connection established flag to true.
- * @note If the client is already connected to a peer, this will return false.
- * @note This is designed to be used when a connection is made outside of the
- * NimBLEClient class, such as when a connection is made by the
- * NimBLEServer class and the client is passed the connection info.
- * This enables the GATT Server to read the attributes of the client connected to it.
- */
-bool NimBLEClient::setConnection(const NimBLEConnInfo& connInfo) {
-    if (isConnected()) {
-        NIMBLE_LOGE(LOG_TAG, "Already connected");
-        return false;
-    }
-
-    m_peerAddress = connInfo.getAddress();
-    m_connHandle  = connInfo.getConnHandle();
-    return true;
-} // setConnection
-
-/**
- * @brief Set the connection information for this client.
- * @param [in] connHandle The connection handle.
- * @note Sets the connection established flag to true.
- * @note This is designed to be used when a connection is made outside of the
- * NimBLEClient class, such as when a connection is made by the
- * NimBLEServer class and the client is passed the connection handle.
- * This enables the GATT Server to read the attributes of the client connected to it.
- * @note If the client is already connected to a peer, this will return false.
- * @note This will look up the peer address using the connection handle.
- */
-bool NimBLEClient::setConnection(uint16_t connHandle) {
-    // we weren't provided the peer address, look it up using ble_gap_conn_find
-    NimBLEConnInfo connInfo;
-    int            rc = ble_gap_conn_find(connHandle, &connInfo.m_desc);
-    if (rc != 0) {
-        NIMBLE_LOGE(LOG_TAG, "Connection info not found");
-        return false;
-    }
-
-    return setConnection(connInfo);
-} // setConnection
-
-/**
  * @brief Retrieve the address of the peer.
  * @return A NimBLEAddress instance with the peer address data.
  */

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -60,9 +60,6 @@ class NimBLEClient {
     void           setClientCallbacks(NimBLEClientCallbacks* pClientCallbacks, bool deleteCallbacks = true);
     std::string    toString() const;
     uint16_t       getConnHandle() const;
-    void           clearConnection();
-    bool           setConnection(const NimBLEConnInfo& connInfo);
-    bool           setConnection(uint16_t connHandle);
     uint16_t       getMTU() const;
     bool           exchangeMTU();
     bool           secureConnection() const;
@@ -139,6 +136,7 @@ class NimBLEClient {
     ble_gap_conn_params m_connParams;
 
     friend class NimBLEDevice;
+    friend class NimBLEServer;
 }; // class NimBLEClient
 
 /**
@@ -154,7 +152,7 @@ class NimBLEClientCallbacks {
      */
     virtual void onConnect(NimBLEClient* pClient);
 
-        /**
+    /**
      * @brief Called when a connection attempt fails.
      * @param [in] pClient A pointer to the connecting client object.
      * @param [in] reason Contains the reason code for the connection failure.

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -48,6 +48,9 @@ class NimBLEExtAdvertising;
 # else
 class NimBLEAdvertising;
 # endif
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+class NimBLEClient;
+# endif
 
 /**
  * @brief The model of a BLE server.
@@ -76,6 +79,12 @@ class NimBLEServer {
     void                  getPeerNameOnConnect(bool enable);
     void                  advertiseOnDisconnect(bool enable);
     void                  setDataLen(uint16_t connHandle, uint16_t tx_octets) const;
+
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+    NimBLEClient* getClient(uint16_t connHandle);
+    NimBLEClient* getClient(const NimBLEConnInfo& connInfo);
+    void          deleteClient();
+# endif
 
 # if CONFIG_BT_NIMBLE_EXT_ADV
     NimBLEExtAdvertising* getAdvertising() const;
@@ -114,6 +123,10 @@ class NimBLEServer {
     NimBLEServerCallbacks*                                 m_pServerCallbacks;
     std::vector<NimBLEService*>                            m_svcVec;
     std::array<uint16_t, CONFIG_BT_NIMBLE_MAX_CONNECTIONS> m_connectedPeers;
+
+# if defined(CONFIG_BT_NIMBLE_ROLE_CENTRAL)
+    NimBLEClient* m_pClient{nullptr};
+# endif
 
     static int  handleGapEvent(struct ble_gap_event* event, void* arg);
     static int  handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_gatt_access_ctxt* ctxt, void* arg);

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -29,7 +29,6 @@
 # undef max
 /**************************/
 
-# include <string>
 # include <vector>
 # include <array>
 
@@ -75,8 +74,6 @@ class NimBLEServer {
     NimBLEConnInfo        getPeerInfo(uint8_t index) const;
     NimBLEConnInfo        getPeerInfo(const NimBLEAddress& address) const;
     NimBLEConnInfo        getPeerInfoByHandle(uint16_t connHandle) const;
-    std::string           getPeerName(const NimBLEConnInfo& connInfo) const;
-    void                  getPeerNameOnConnect(bool enable);
     void                  advertiseOnDisconnect(bool enable);
     void                  setDataLen(uint16_t connHandle, uint16_t tx_octets) const;
 
@@ -114,7 +111,6 @@ class NimBLEServer {
     ~NimBLEServer();
 
     bool m_gattsStarted : 1;
-    bool m_getPeerNameOnConnect : 1;
     bool m_svcChanged : 1;
     bool m_deleteCallbacks : 1;
 # if !CONFIG_BT_NIMBLE_EXT_ADV
@@ -128,17 +124,15 @@ class NimBLEServer {
     NimBLEClient* m_pClient{nullptr};
 # endif
 
-    static int  handleGapEvent(struct ble_gap_event* event, void* arg);
-    static int  handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_gatt_access_ctxt* ctxt, void* arg);
-    static int  peerNameCB(uint16_t connHandle, const ble_gatt_error* error, ble_gatt_attr* attr, void* arg);
-    std::string getPeerNameImpl(uint16_t connHandle, int cb_type = -1) const;
-    void        serviceChanged();
-    void        resetGATT();
+    static int handleGapEvent(struct ble_gap_event* event, void* arg);
+    static int handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_gatt_access_ctxt* ctxt, void* arg);
+    void       serviceChanged();
+    void       resetGATT();
 
 }; // NimBLEServer
 
 /**
- * @brief Callbacks associated with the operation of a %BLE server.
+ * @brief Callbacks associated with the operation of a BLE server.
  */
 class NimBLEServerCallbacks {
   public:
@@ -147,26 +141,16 @@ class NimBLEServerCallbacks {
     /**
      * @brief Handle a client connection.
      * This is called when a client connects.
-     * @param [in] pServer A pointer to the %BLE server that received the client connection.
+     * @param [in] pServer A pointer to the BLE server that received the client connection.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance with information.
      * about the peer connection parameters.
      */
     virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo);
 
     /**
-     * @brief Handle a client connection.
-     * This is called when a client connects.
-     * @param [in] pServer A pointer to the %BLE server that received the client connection.
-     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information.
-     * @param [in] name The name of the connected peer device.
-     * about the peer connection parameters.
-     */
-    virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, std::string& name);
-
-    /**
      * @brief Handle a client disconnection.
-     * This is called when a client discconnects.
-     * @param [in] pServer A pointer to the %BLE server that received the client disconnection.
+     * This is called when a client disconnects.
+     * @param [in] pServer A pointer to the BLE server that received the client disconnection.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
      * about the peer connection parameters.
      * @param [in] reason The reason code for the disconnection.
@@ -201,14 +185,6 @@ class NimBLEServerCallbacks {
      * about the peer connection parameters.
      */
     virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo);
-
-    /**
-     * @brief Called when the pairing procedure is complete.
-     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
-     * @param [in] name The name of the connected peer device.
-     * about the peer connection parameters.
-     */
-    virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo, const std::string& name);
 
     /**
      * @brief Called when the peer identity address is resolved.


### PR DESCRIPTION
This allows the NimBLEServer instance to create a NimBLEClient instance to read/write form/to a connected peer. Only one instance is supported subsequent calls will overwrite the previous client connection information and data.