### PR TITLE
Add a workaround for esp32s3 and esp32c3 tx power bug

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -425,10 +425,19 @@ std::vector<NimBLEClient*> NimBLEDevice::getConnectedClients() {
 #  ifndef CONFIG_IDF_TARGET_ESP32P4
 /**
  * @brief Get the transmission power.
- * @return The power level currently used in esp_power_level_t.
+ * @return The power level currently used in esp_power_level_t or a negative value on error.
  */
 esp_power_level_t NimBLEDevice::getPowerLevel(esp_ble_power_type_t powerType) {
-    return esp_ble_tx_power_get(powerType);
+    esp_power_level_t pwr = esp_ble_tx_power_get(powerType);
+
+#   if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+    // workaround for bug when "enhanced tx power" was added
+    if (pwr == 0xFF) {
+        pwr = esp_ble_tx_power_get(ESP_BLE_PWR_TYPE_CONN_HDL3);
+    }
+#   endif
+
+    return pwr;
 } // getPowerLevel
 
 /**
@@ -486,15 +495,7 @@ int NimBLEDevice::getPower() {
 #  ifdef CONFIG_IDF_TARGET_ESP32P4
     return 0xFF; // CONFIG_IDF_TARGET_ESP32P4 does not support esp_ble_tx_power_get
 #  else
-    int pwr = esp_ble_tx_power_get(ESP_BLE_PWR_TYPE_DEFAULT);
-
-#   if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
-    // workaround for bug when "enhanced tx power" was added
-    if (pwr == 0xFF) {
-        pwr = esp_ble_tx_power_get(ESP_BLE_PWR_TYPE_CONN_HDL3);
-    }
-#   endif
-
+    int pwr = getPowerLevel();
     if (pwr < 0) {
         NIMBLE_LOGE(LOG_TAG, "esp_ble_tx_power_get failed rc=%d", pwr);
         return 0xFF;


### PR DESCRIPTION
This adds a workaround to get the tx power when the function returns error due to a bug introduced in some versions of esp-idf.

* Added error checking, return value will be 0xFF if there was an error.