### PR TITLE
[BREAKING] Remove NimBLEAddress type default value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - `NimBLEService::getCharacteristics` now returns a `const std::vector<NimBLECharacteristic*>&` instead of std::vector<NimBLECharacteristic *>.
 - `NimBLEUUID::getNative` method replaced with `NimBLEUUID::getBase` which returns a read-only pointer to the underlying `ble_uuid_t` struct.
 - `NimBLEUUID`; `msbFirst` parameter has been removed from constructor, caller should reverse the data first or call the new `reverseByteOrder` method after.
+- `NimBLEAddress` constructor; default value for the `type` parameter removed, caller should know the address type and specify it.
 - `NimBLEAddress::getNative` replaced with `NimBLEAddress::getBase` and now returns a pointer to `const ble_addr_t` instead of a pointer to the address value.
 - `NimBLEAddress::equals` method and `NimBLEAddress::== operator` will now also test if the address types are the same.
 - `NimBLEUtils::dumpGapEvent` function removed.

--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -45,7 +45,9 @@ NimBLEAddress::NimBLEAddress(ble_addr_t address) : ble_addr_t{address} {}
  * ```
  * which is 17 characters in length.
  * @param [in] addr The hex string representation of the address.
- * @param [in] type The type of the address.
+ * @param [in] type The type of the address, should be one of:
+ * * BLE_ADDR_PUBLIC (0)
+ * * BLE_ADDR_RANDOM (1)
  */
 NimBLEAddress::NimBLEAddress(const std::string& addr, uint8_t type) {
     this->type = type;
@@ -70,7 +72,9 @@ NimBLEAddress::NimBLEAddress(const std::string& addr, uint8_t type) {
 /**
  * @brief Constructor for compatibility with bluedroid esp library using native ESP representation.
  * @param [in] address A uint8_t[6] or esp_bd_addr_t containing the address.
- * @param [in] type The type of the address.
+ * @param [in] type The type of the address should be one of:
+ * * BLE_ADDR_PUBLIC (0)
+ * * BLE_ADDR_RANDOM (1)
  */
 NimBLEAddress::NimBLEAddress(const uint8_t address[BLE_DEV_ADDR_LEN], uint8_t type) {
     std::reverse_copy(address, address + BLE_DEV_ADDR_LEN, this->val);
@@ -81,7 +85,9 @@ NimBLEAddress::NimBLEAddress(const uint8_t address[BLE_DEV_ADDR_LEN], uint8_t ty
  * @brief Constructor for address using a hex value.\n
  * Use the same byte order, so use 0xa4c1385def16 for "a4:c1:38:5d:ef:16"
  * @param [in] address uint64_t containing the address.
- * @param [in] type The type of the address.
+ * @param [in] type The type of the address should be one of:
+ * * BLE_ADDR_PUBLIC (0)
+ * * BLE_ADDR_RANDOM (1)
  */
 NimBLEAddress::NimBLEAddress(const uint64_t& address, uint8_t type) {
     memcpy(this->val, &address, sizeof this->val);

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -34,9 +34,9 @@
 # include <string>
 
 /**
- * @brief A %BLE device address.
+ * @brief A BLE device address.
  *
- * Every %BLE device has a unique address which can be used to identify it and form connections.
+ * Every BLE device has a unique address which can be used to identify it and form connections.
  */
 class NimBLEAddress : private ble_addr_t {
   public:
@@ -45,9 +45,9 @@ class NimBLEAddress : private ble_addr_t {
      */
     NimBLEAddress() = default;
     NimBLEAddress(const ble_addr_t address);
-    NimBLEAddress(const uint8_t address[BLE_DEV_ADDR_LEN], uint8_t type = BLE_ADDR_PUBLIC);
-    NimBLEAddress(const std::string& stringAddress, uint8_t type = BLE_ADDR_PUBLIC);
-    NimBLEAddress(const uint64_t& address, uint8_t type = BLE_ADDR_PUBLIC);
+    NimBLEAddress(const uint8_t address[BLE_DEV_ADDR_LEN], uint8_t type);
+    NimBLEAddress(const std::string& stringAddress, uint8_t type);
+    NimBLEAddress(const uint64_t& address, uint8_t type);
 
     bool                 isRpa() const;
     bool                 isNrpa() const;

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -614,18 +614,14 @@ bool NimBLEDevice::isBonded(const NimBLEAddress& address) {
 /**
  * @brief Get the address of a bonded peer device by index.
  * @param [in] index The index to retrieve the peer address of.
- * @returns NimBLEAddress of the found bonded peer or nullptr if not found.
+ * @returns NimBLEAddress of the found bonded peer or null address if not found.
  */
 NimBLEAddress NimBLEDevice::getBondedAddress(int index) {
     ble_addr_t peer_id_addrs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int        num_peers, rc;
     rc = ble_store_util_bonded_peers(&peer_id_addrs[0], &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
-    if (rc != 0) {
-        return nullptr;
-    }
-
-    if (index > num_peers || index < 0) {
-        return nullptr;
+    if (rc != 0 || index > num_peers || index < 0) {
+        return NimBLEAddress{};
     }
 
     return NimBLEAddress(peer_id_addrs[index]);
@@ -704,12 +700,12 @@ size_t NimBLEDevice::getWhiteListCount() {
 /**
  * @brief Gets the address at the vector index.
  * @param [in] index The vector index to retrieve the address from.
- * @returns The NimBLEAddress at the whitelist index or nullptr if not found.
+ * @returns The NimBLEAddress at the whitelist index or null address if not found.
  */
 NimBLEAddress NimBLEDevice::getWhiteListAddress(size_t index) {
     if (index > m_whiteList.size()) {
         NIMBLE_LOGE(LOG_TAG, "Invalid index; %u", index);
-        return nullptr;
+        return NimBLEAddress{};
     }
 
     return m_whiteList[index];


### PR DESCRIPTION
When constructing a NimBLEAddress via string or other non `ble_addr_t` parameters it is important that the address type be specified. This will help prevent issues where applications are not able to connect or identify scanned devices when comparing their addresses.