### PR TITLE
NimBLEScan increment m_callbackSent before callback.

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -119,19 +119,19 @@ int NimBLEScan::handleGapEvent(ble_gap_event* event, void* arg) {
             }
 
             if (!advertisedDevice->m_callbackSent) {
-                pScan->m_pScanCallbacks->onDiscovered(advertisedDevice);
                 advertisedDevice->m_callbackSent++;
+                pScan->m_pScanCallbacks->onDiscovered(advertisedDevice);
             }
 
             // If not active scanning or scan response is not available
             // or extended advertisement scanning, report the result to the callback now.
             if (pScan->m_scanParams.passive || !isLegacyAdv || !advertisedDevice->isScannable()) {
-                pScan->m_pScanCallbacks->onResult(advertisedDevice);
                 advertisedDevice->m_callbackSent++;
+                pScan->m_pScanCallbacks->onResult(advertisedDevice);
             } else if (isLegacyAdv && event_type == BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP) {
+                advertisedDevice->m_callbackSent++;
                 // got the scan response report the full data.
                 pScan->m_pScanCallbacks->onResult(advertisedDevice);
-                advertisedDevice->m_callbackSent++;
             }
 
             // If not storing results and we have invoked the callback, delete the device.


### PR DESCRIPTION
Fixes heap corruption observed on CONFIG_HEAP_POISONING_COMPREHENSIVE.
Resolves https://github.com/h2zero/esp-nimble-cpp/issues/277