### PR TITLE
Add explicit keyword to constructors

### DIFF
--- a/src/NimBLE2904.h
+++ b/src/NimBLE2904.h
@@ -38,7 +38,7 @@ struct NimBLE2904Data {
  */
 class NimBLE2904 : public NimBLEDescriptor {
   public:
-    NimBLE2904(NimBLECharacteristic* pChr = nullptr);
+    explicit NimBLE2904(NimBLECharacteristic* pChr = nullptr);
     static const uint8_t FORMAT_BOOLEAN   = 1;
     static const uint8_t FORMAT_UINT2     = 2;
     static const uint8_t FORMAT_UINT4     = 3;

--- a/src/NimBLEAddress.h
+++ b/src/NimBLEAddress.h
@@ -44,10 +44,10 @@ class NimBLEAddress : private ble_addr_t {
      * @brief Create a blank address, i.e. 00:00:00:00:00:00, type 0.
      */
     NimBLEAddress() = default;
-    NimBLEAddress(const ble_addr_t address);
     NimBLEAddress(const uint8_t address[BLE_DEV_ADDR_LEN], uint8_t type);
     NimBLEAddress(const std::string& stringAddress, uint8_t type);
     NimBLEAddress(const uint64_t& address, uint8_t type);
+    explicit NimBLEAddress(const ble_addr_t address);
 
     bool                 isRpa() const;
     bool                 isNrpa() const;

--- a/src/NimBLEAttValue.h
+++ b/src/NimBLEAttValue.h
@@ -84,7 +84,7 @@ class NimBLEAttValue {
      * @param[in] init_len The initial size in bytes.
      * @param[in] max_len The max size in bytes that the value can be.
      */
-    NimBLEAttValue(uint16_t init_len = CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN);
+    explicit NimBLEAttValue(uint16_t init_len = CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN);
 
     /**
      * @brief Construct with an initial value from a buffer.
@@ -99,7 +99,7 @@ class NimBLEAttValue {
      * @param value A pointer to the initial value to set.
      * @param[in] max_len The max size in bytes that the value can be.
      */
-    NimBLEAttValue(const char* value, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
+    explicit NimBLEAttValue(const char* value, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
         : NimBLEAttValue((uint8_t*)value, (uint16_t)strlen(value), max_len) {}
 
     /**
@@ -115,7 +115,7 @@ class NimBLEAttValue {
      * @param str A std::string containing to the initial value to set.
      * @param[in] max_len The max size in bytes that the value can be.
      */
-    NimBLEAttValue(const std::string str, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
+    explicit NimBLEAttValue(const std::string& str, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
         : NimBLEAttValue(reinterpret_cast<const uint8_t*>(&str[0]), str.length(), max_len) {}
 
     /**
@@ -123,7 +123,7 @@ class NimBLEAttValue {
      * @param vec A std::vector<uint8_t> containing to the initial value to set.
      * @param[in] max_len The max size in bytes that the value can be.
      */
-    NimBLEAttValue(const std::vector<uint8_t> vec, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
+    explicit NimBLEAttValue(const std::vector<uint8_t>& vec, uint16_t max_len = BLE_ATT_ATTR_MAX_LEN)
         : NimBLEAttValue(&vec[0], vec.size(), max_len) {}
 
 # ifdef NIMBLE_CPP_ARDUINO_STRING_AVAILABLE

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -39,14 +39,14 @@ class NimBLE2904;
  */
 class NimBLECharacteristic : public NimBLELocalValueAttribute {
   public:
-    NimBLECharacteristic(const char*    uuid,
-                         uint16_t       properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                         uint16_t       maxLen     = BLE_ATT_ATTR_MAX_LEN,
-                         NimBLEService* pService   = nullptr);
-    NimBLECharacteristic(const NimBLEUUID& uuid,
-                         uint16_t          properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
-                         uint16_t          maxLen     = BLE_ATT_ATTR_MAX_LEN,
-                         NimBLEService*    pService   = nullptr);
+    explicit NimBLECharacteristic(const char*    uuid,
+                                  uint16_t       properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
+                                  uint16_t       maxLen     = BLE_ATT_ATTR_MAX_LEN,
+                                  NimBLEService* pService   = nullptr);
+    explicit NimBLECharacteristic(const NimBLEUUID& uuid,
+                                  uint16_t          properties = NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE,
+                                  uint16_t          maxLen     = BLE_ATT_ATTR_MAX_LEN,
+                                  NimBLEService*    pService   = nullptr);
 
     ~NimBLECharacteristic();
 

--- a/src/NimBLEConnInfo.h
+++ b/src/NimBLEConnInfo.h
@@ -78,6 +78,6 @@ class NimBLEConnInfo {
 
     ble_gap_conn_desc m_desc{};
     NimBLEConnInfo() {};
-    NimBLEConnInfo(ble_gap_conn_desc desc) { m_desc = desc; }
+    explicit NimBLEConnInfo(ble_gap_conn_desc desc) : m_desc(desc) {}
 };
 #endif

--- a/src/NimBLEService.h
+++ b/src/NimBLEService.h
@@ -33,8 +33,8 @@ class NimBLEService;
  */
 class NimBLEService : public NimBLELocalAttribute {
   public:
-    NimBLEService(const char* uuid);
-    NimBLEService(const NimBLEUUID& uuid);
+    explicit NimBLEService(const char* uuid);
+    explicit NimBLEService(const NimBLEUUID& uuid);
     ~NimBLEService();
 
     NimBLEServer*         getServer() const;

--- a/src/NimBLEUUID.h
+++ b/src/NimBLEUUID.h
@@ -45,12 +45,12 @@ class NimBLEUUID {
      */
     NimBLEUUID() = default;
     NimBLEUUID(const ble_uuid_any_t& uuid);
-    NimBLEUUID(const std::string& uuid);
-    NimBLEUUID(uint16_t uuid);
-    NimBLEUUID(uint32_t uuid);
-    NimBLEUUID(const ble_uuid128_t* uuid);
     NimBLEUUID(const uint8_t* pData, size_t size);
     NimBLEUUID(uint32_t first, uint16_t second, uint16_t third, uint64_t fourth);
+    explicit NimBLEUUID(const std::string& uuid);
+    explicit NimBLEUUID(uint16_t uuid);
+    explicit NimBLEUUID(uint32_t uuid);
+    explicit NimBLEUUID(const ble_uuid128_t* uuid);
 
     uint8_t           bitSize() const;
     const uint8_t*    getValue() const;

--- a/src/NimBLEUtils.h
+++ b/src/NimBLEUtils.h
@@ -30,7 +30,7 @@ class NimBLEAddress;
  * All items are optional, the m_pHandle will be set in taskWait().
  */
 struct NimBLETaskData {
-    NimBLETaskData(void* pInstance = nullptr, int flags = 0, void* buf = nullptr);
+    explicit NimBLETaskData(void* pInstance = nullptr, int flags = 0, void* buf = nullptr);
     ~NimBLETaskData();
     void*       m_pInstance{nullptr};
     mutable int m_flags{0};


### PR DESCRIPTION
Resolves cppcheck warnings noExplicitConstructor, and useInitializationList.