### PR TITLE
NimBLEAddress::toString allow formatting to be configured

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -157,6 +157,20 @@ config NIMBLE_CPP_ENABLE_ADVERTISEMENT_TYPE_TEXT
         while scanning as text messages in the debug log.
         This will use approximately 250 bytes of flash memory.
 
+config NIMBLE_CPP_ADDR_FMT_INCLUDE_DELIMITER
+    bool "Show colon characters when printing address."
+    default "y"
+    help
+        Enabling this option will format MAC addresses with
+        colon characters included when printing.
+
+config NIMBLE_CPP_ADDR_FMT_UPPERCASE
+    bool "Use uppercase letters when printing address."
+    default "n"
+    help
+        Enabling this option will format MAC addresses in
+        uppercase letters when printing.
+
 config NIMBLE_CPP_ATT_VALUE_TIMESTAMP_ENABLED
     bool "Enable timestamps to be stored with attribute values."
     default "n"

--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -23,6 +23,18 @@
 
 # include <algorithm>
 
+# ifdef CONFIG_NIMBLE_CPP_ADDR_FMT_INCLUDE_DELIMITER
+#  define NIMBLE_CPP_ADDR_DELIMITER ":"
+# else
+#  define NIMBLE_CPP_ADDR_DELIMITER ""
+# endif
+
+# ifdef CONFIG_NIMBLE_CPP_ADDR_FMT_UPPERCASE
+#  define NIMBLE_CPP_ADDR_FMT "%02X%s%02X%s%02X%s%02X%s%02X%s%02X"
+# else
+#  define NIMBLE_CPP_ADDR_FMT "%02x%s%02x%s%02x%s%02x%s%02x%s%02x"
+# endif
+
 static const char* LOG_TAG = "NimBLEAddress";
 
 /*************************************************
@@ -211,12 +223,12 @@ NimBLEAddress::operator std::string() const {
     char buffer[18];
     snprintf(buffer,
              sizeof(buffer),
-             "%02x:%02x:%02x:%02x:%02x:%02x",
-             this->val[5],
-             this->val[4],
-             this->val[3],
-             this->val[2],
-             this->val[1],
+             NIMBLE_CPP_ADDR_FMT,
+             this->val[5], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[4], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[3], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[2], NIMBLE_CPP_ADDR_DELIMITER,
+             this->val[1], NIMBLE_CPP_ADDR_DELIMITER,
              this->val[0]);
     return std::string{buffer};
 } // operator std::string


### PR DESCRIPTION
* Added Kconfig bool option `NIMBLE_CPP_ADDR_FMT_UPPERCASE`
  If enabled, allows address to be printed in uppercase letters. (Default: No)
* Added Kconfig bool option `NIMBLE_CPP_ADDR_FMT_INCLUDE_DELIMITER`
  If enabled, allows address to be printed with colon characters included. (Default: Yes)