### PR TITLE
Fix race condition in NimBLEScan::clearResults.

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -468,10 +468,15 @@ NimBLEScanResults NimBLEScan::getResults() {
  * @brief Clear the stored results of the scan.
  */
 void NimBLEScan::clearResults() {
-    for (const auto& dev : m_scanResults.m_deviceVec) {
-        delete dev;
+    if (m_scanResults.m_deviceVec.size()) {
+        std::vector<NimBLEAdvertisedDevice*> vSwap{};
+        ble_npl_hw_enter_critical();
+        vSwap.swap(m_scanResults.m_deviceVec);
+        ble_npl_hw_exit_critical(0);
+        for (const auto& dev : vSwap) {
+            delete dev;
+        }
     }
-    std::vector<NimBLEAdvertisedDevice*>().swap(m_scanResults.m_deviceVec);
 } // clearResults
 
 /**


### PR DESCRIPTION
If clear results is called from more than one task a race condition exists that may delete the same advertisedDevice twice. This prevents this by swapping with an empty vector and testing for empty before freeing the resources.