### PR TITLE
fix(NimBLEDevice): fix crash when pairing table is full

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -76,7 +76,8 @@ extern "C" void ble_store_config_init(void);
 /**
  * Singletons for the NimBLEDevice.
  */
-NimBLEDeviceCallbacks* NimBLEDevice::m_pDeviceCallbacks = nullptr;
+NimBLEDeviceCallbacks NimBLEDevice::defaultDeviceCallbacks{};
+NimBLEDeviceCallbacks* NimBLEDevice::m_pDeviceCallbacks = &defaultDeviceCallbacks;
 
 # if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 NimBLEScan* NimBLEDevice::m_pScan = nullptr;


### PR DESCRIPTION
* Add missing definition for default device callbacks (which prevents calling the `setDeviceCallbacks` method)
* Ensure `m_pDeviceCallbacks` inital value is set to `&defaultDeviceCallbacks` to prevent crash when pairing table is full

After #295 any time the pairing table fills up, the device will crash on the next pairing attempt.

Log when trying to build code that calls `setDeviceCallbacks`:

```console
/Users/bob/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: esp-idf/esp-nimble-cpp/libesp-nimble-cpp.a(NimBLEDevice.cpp.obj):(.literal._ZN12NimBLEDevice18setDeviceCallbacksEP21NimBLEDeviceCallbacks+0x0): undefined reference to `_ZN12NimBLEDevice22defaultDeviceCallbacksE'
collect2: error: ld returned 1 exit status
```

Code causing crash `NimBLEDevice.cpp:905`:
```c++
        ble_hs_cfg.store_status_cb = [](struct ble_store_status_event* event, void* arg) {
            return m_pDeviceCallbacks->onStoreStatus(event, arg);
        };
```

This is because by default `m_pDeviceCallbacks = nullptr`.

It cannot be set, because calling `setDeviceCallbacks` runs

```c++
void NimBLEDevice::setDeviceCallbacks(NimBLEDeviceCallbacks* cb) {
    m_pDeviceCallbacks = cb ? cb : &defaultDeviceCallbacks;
}
```

but you cannot get the address of a static member that has not been defined.

Log for crash when pairing table is full:

```console
[Hid Service Example/I][16.627]: Device authenticated
call store status cb
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x42018cdb  PS      : 0x00060b30  A0      : 0x82018cf8  A1      : 0x3fcb6350
--- 0x42018cdb: NimBLEDevice::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda(ble_store_status_event*, void*)#1}::operator()(ble_store_status_event*, void*) const at /Users/bob/backbone/niji/components/espp/components/esp-nimble-cpp/src/NimBLEDevice.cpp:908

A2      : 0x00000000  A3      : 0x3fcb63b0  A4      : 0x00000000  A5      : 0x3fcb6366
A6      : 0x00000001  A7      : 0x3fcb6764  A8      : 0x3fc9d5dc  A9      : 0x3fcb6330
A10     : 0x00000000  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00000000
A14     : 0x00000000  A15     : 0x3fcb4754  SAR     : 0x00000010  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000000  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffffa
--- 0x400556d5: strlen in ROM
0x400556e5: strlen in ROM



Backtrace: 0x42018cd8:0x3fcb6350 0x42018cf5:0x3fcb6370 0x420208e9:0x3fcb6390 0x42020971:0x3fcb63b0 0x420209a5:0x3fcb63e0 0x42020a81:0x3fcb6400 0x420253e4:0x3fcb6420 0x4202a5a1:0x3fcb6470 0x4202adf5:0x3fcb64a0 0x4202b7a9:0x3fcb64c0 0x4201edf1:0x3fcb64f0 0x4201ec86:0x3fcb6520 0x4201e1bd:0x3fcb6550 0x4201e1cf:0x3fcb6570 0x4208d5db:0x3fcb6590 0x40377332:0x3fcb65b0 0x42018cc2:0x3fcb65d0 0x403809a5:0x3fcb65f0
--- 0x42018cd8: NimBLEDevice::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda(ble_store_status_event*, void*)#1}::operator()(ble_store_status_event*, void*) const at /Users/bob/backbone/niji/components/espp/components/esp-nimble-cpp/src/NimBLEDevice.cpp:908
0x42018cf5: NimBLEDevice::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda(ble_store_status_event*, void*)#1}::_FUN(ble_store_status_event*, void*) at /Users/bob/backbone/niji/components/espp/components/esp-nimble-cpp/src/NimBLEDevice.cpp:909
0x420208e9: ble_store_status at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_store.c:107
0x42020971: ble_store_overflow_event at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_store.c:122
0x420209a5: ble_store_write at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_store.c:65
0x42020a81: ble_store_write_cccd at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_store.c:273
0x420253e4: ble_gatts_clt_cfg_access at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gatts.c:1000
0x4202a5a1: ble_att_svr_write at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:586
0x4202adf5: ble_att_svr_write_handle at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:617
0x4202b7a9: ble_att_svr_rx_write at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att_svr.c:2304
0x4201edf1: ble_att_rx at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_att.c:517
0x4201ec86: ble_hs_hci_evt_acl_process at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_hs_hci_evt.c:1251
0x4201e1bd: ble_hs_process_rx_data_queue at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_hs.c:248
0x4201e1cf: ble_hs_event_rx_data at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_hs.c:545
0x4208d5db: npl_freertos_event_run at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/porting/npl/freertos/src/npl_os_freertos.c:451
0x40377332: ble_npl_event_run at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h:185
 (inlined by) nimble_port_run at /Users/bob/esp/esp-idf/components/bt/host/nimble/nimble/porting/nimble/src/nimble_port.c:309
0x42018cc2: NimBLEDevice::host_task(void*) at /Users/bob/backbone/niji/components/espp/components/esp-nimble-cpp/src/NimBLEDevice.cpp:835
0x403809a5: vPortTaskWrapper at /Users/bob/esp/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:139
```