### PR TITLE
Allow `esp_wifi_remote` >= 0.5.3

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -16,7 +16,7 @@ dependencies:
     rules:
       - if: "target in [esp32p4]"
   espressif/esp_wifi_remote:
-    version: "<0.5.4"
+    version: ">=0.5.3"
     rules:
       - if: "target in [esp32p4]"
   idf:


### PR DESCRIPTION
`esp_wifi_remote` >= v0.10.0 is necessary to use esp-nimble-cpp with the latest ESP-IDF master branch.

Alternately, if we can drop `esp_wifi_remote` as a dependency of this project, that'd be even better.