### PR TITLE
[Bugfix] NimBLEScan delete.

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -41,7 +41,9 @@ NimBLEScan::NimBLEScan()
  * @brief Scan destructor, release any allocated resources.
  */
 NimBLEScan::~NimBLEScan() {
-    clearResults();
+    for (const auto& dev : m_scanResults.m_deviceVec) {
+        delete dev;
+    }
 }
 
 /**


### PR DESCRIPTION
Calling NimBLEDevice::deint with the `clearAll` parameter set to `true` will delete the scan and any scan results but it was calling `clearall` which uses critical sections, this could cause a crash because the stack has already been de-initialized.