### PR TITLE
Fix server client read/write not returning when encryption is used.

### DIFF
--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -530,6 +530,11 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
             }
 
             pServer->m_pServerCallbacks->onAuthenticationComplete(peerInfo);
+# if CONFIG_BT_NIMBLE_ROLE_CENTRAL
+            if (pServer->m_pClient && pServer->m_pClient->m_connHandle == event->enc_change.conn_handle) {
+                NimBLEClient::handleGapEvent(event, pServer->m_pClient);
+            }
+# endif
             break;
         } // BLE_GAP_EVENT_ENC_CHANGE
 


### PR DESCRIPTION
When the client created by the server reads or writes to an attribute and it triggers a pairing action the task will not be released because the client does not get the event. This passes the event to the client to prevent the task from being hung.