### PR TITLE
Fix undefined reference to ble_svc_gap_device_name_set when GATT server is disabled

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1290,12 +1290,13 @@ bool NimBLEDevice::injectConfirmPasskey(const NimBLEConnInfo& peerInfo, bool acc
  * @param [in] deviceName The name to set.
  */
 bool NimBLEDevice::setDeviceName(const std::string& deviceName) {
+#if CONFIG_BT_NIMBLE_GAP_SERVICE    
     int rc = ble_svc_gap_device_name_set(deviceName.c_str());
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Device name not set - too long");
         return false;
     }
-
+#endif
     return true;
 } // setDeviceName
 

--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -1290,7 +1290,7 @@ bool NimBLEDevice::injectConfirmPasskey(const NimBLEConnInfo& peerInfo, bool acc
  * @param [in] deviceName The name to set.
  */
 bool NimBLEDevice::setDeviceName(const std::string& deviceName) {
-#if CONFIG_BT_NIMBLE_GAP_SERVICE    
+#if !defined(ESP_IDF_VERSION) || ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0) || CONFIG_BT_NIMBLE_GAP_SERVICE
     int rc = ble_svc_gap_device_name_set(deviceName.c_str());
     if (rc != 0) {
         NIMBLE_LOGE(LOG_TAG, "Device name not set - too long");


### PR DESCRIPTION
Since commit https://github.com/espressif/esp-idf/commit/a58ce394c40cc306bfff7f2f59250e866cb35897 (included in v5.5-RC1) the function `ble_svc_gap_device_name_set` will not be defined in esp-idf when `CONFIG_BT_NIMBLE_GATT_SERVER=n` and compilation of esp-nimble-cpp will fail as a result.

This PR makes calling `ble_svc_gap_device_name_set` conditional on `CONFIG_BT_NIMBLE_GAP_SERVICE` in line with the examples in esp-idf master (see the above commit)