### PR TITLE
Add bidirectional passkey callbacks for Client and Server

### DIFF
--- a/src/NimBLEClient.cpp
+++ b/src/NimBLEClient.cpp
@@ -933,7 +933,6 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
 
     switch (event->type) {
         case BLE_GAP_EVENT_DISCONNECT: {
-
             // workaround for bug in NimBLE stack where disconnect event argument is not passed correctly
             pClient = NimBLEDevice::getClientByPeerAddress(event->disconnect.conn.peer_ota_addr);
             if (pClient == nullptr) {
@@ -946,8 +945,7 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
             }
 
             if (pClient == nullptr) {
-                NIMBLE_LOGE(LOG_TAG, "Disconnected client not found, conn_handle=%d",
-                            event->disconnect.conn.conn_handle);
+                NIMBLE_LOGE(LOG_TAG, "Disconnected client not found, conn_handle=%d", event->disconnect.conn.conn_handle);
                 return 0;
             }
 
@@ -1210,6 +1208,9 @@ int NimBLEClient::handleGapEvent(struct ble_gap_event* event, void* arg) {
                 // pClient->onOobPairingRequest(pkey.oob);
                 // rc = ble_sm_inject_io(event->passkey.conn_handle, &pkey);
                 // NIMBLE_LOGD(LOG_TAG, "ble_sm_inject_io result: %d", rc);
+            } else if (event->passkey.params.action == BLE_SM_IOACT_DISP) {
+                NIMBLE_LOGD(LOG_TAG, "Passkey display: %" PRIu32, event->passkey.params.passkey);
+                pClient->m_pClientCallbacks->onPassKeyDisplay(peerInfo, event->passkey.params.passkey);
             } else if (event->passkey.params.action == BLE_SM_IOACT_INPUT) {
                 NIMBLE_LOGD(LOG_TAG, "Enter the passkey");
                 pClient->m_pClientCallbacks->onPassKeyEntry(peerInfo);
@@ -1302,6 +1303,10 @@ void NimBLEClientCallbacks::onPassKeyEntry(NimBLEConnInfo& connInfo) {
     NIMBLE_LOGD(CB_TAG, "onPassKeyEntry: default: 123456");
     NimBLEDevice::injectPassKey(connInfo, 123456);
 } // onPassKeyEntry
+
+void NimBLEClientCallbacks::onPassKeyDisplay(NimBLEConnInfo& connInfo, uint32_t passkey) {
+    NIMBLE_LOGD(CB_TAG, "onPassKeyDisplay: default: %" PRIu32, passkey);
+} // onPassKeyDisplay
 
 void NimBLEClientCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo) {
     NIMBLE_LOGD(CB_TAG, "onAuthenticationComplete: default");

--- a/src/NimBLEClient.h
+++ b/src/NimBLEClient.h
@@ -188,6 +188,13 @@ class NimBLEClientCallbacks {
     virtual void onPassKeyEntry(NimBLEConnInfo& connInfo);
 
     /**
+     * @brief Called when a passkey should be displayed for pairing.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
+     * @param [in] passkey The passkey to display.
+     */
+    virtual void onPassKeyDisplay(NimBLEConnInfo& connInfo, uint32_t passkey);
+
+    /**
      * @brief Called when the pairing procedure is complete.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.\n
      * This can be used to check the status of the connection encryption/pairing.

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -594,6 +594,14 @@ int NimBLEServer::handleGapEvent(ble_gap_event* event, void* arg) {
                 rc = ble_sm_inject_io(event->passkey.conn_handle, &pkey);
                 NIMBLE_LOGD(LOG_TAG, "BLE_SM_IOACT_DISP; ble_sm_inject_io result: %d", rc);
 
+            } else if (event->passkey.params.action == BLE_SM_IOACT_INPUT) {
+                NIMBLE_LOGD(LOG_TAG, "Enter the passkey");
+                rc = ble_gap_conn_find(event->passkey.conn_handle, &peerInfo.m_desc);
+                if (rc != 0) {
+                    return BLE_ATT_ERR_INVALID_HANDLE;
+                }
+                pServer->m_pServerCallbacks->onPassKeyEntry(peerInfo);
+
             } else if (event->passkey.params.action == BLE_SM_IOACT_NUMCMP) {
                 NIMBLE_LOGD(LOG_TAG, "Passkey on device's display: %" PRIu32, event->passkey.params.numcmp);
 
@@ -1024,6 +1032,11 @@ uint32_t NimBLEServerCallbacks::onPassKeyDisplay() {
     NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyDisplay: default: 123456");
     return 123456;
 } // onPassKeyDisplay
+
+void NimBLEServerCallbacks::onPassKeyEntry(NimBLEConnInfo& connInfo) {
+    NIMBLE_LOGD("NimBLEServerCallbacks", "onPassKeyEntry: default: 123456");
+    NimBLEDevice::injectPassKey(connInfo, 123456);
+} // onPassKeyEntry
 
 void NimBLEServerCallbacks::onConfirmPassKey(NimBLEConnInfo& connInfo, uint32_t pin) {
     NIMBLE_LOGD("NimBLEServerCallbacks", "onConfirmPasskey: default: true");

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -180,6 +180,13 @@ class NimBLEServerCallbacks {
     virtual uint32_t onPassKeyDisplay();
 
     /**
+     * @brief Called when a passkey should be entered for pairing.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
+     * about the peer connection parameters.
+     */
+    virtual void onPassKeyEntry(NimBLEConnInfo& connInfo);
+
+    /**
      * @brief Called when using numeric comparision for pairing.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance with information
      * Should be passed back to NimBLEDevice::injectConfirmPasskey


### PR DESCRIPTION
## Summary

This PR adds missing passkey callbacks to enable full bidirectional passkey support for both Client and Server roles.

## Changes

### Client (Central) - Added `onPassKeyDisplay`
- Added `onPassKeyDisplay` callback to `NimBLEClientCallbacks`
- Handles `BLE_SM_IOACT_DISP` action in Client's GAP event handler
- Allows Client to display passkey during pairing (previously only supported entry)

### Server (Peripheral) - Added `onPassKeyEntry`
- Added `onPassKeyEntry` callback to `NimBLEServerCallbacks`
- Handles `BLE_SM_IOACT_INPUT` action in Server's GAP event handler
- Allows Server to request passkey input during pairing (previously only supported display)

## Motivation

Currently, the library only supports:
- **Client (Central)**: `onPassKeyEntry` (input only)
- **Server (Peripheral)**: `onPassKeyDisplay` (display only)

This limitation prevents dual-role devices from using different IO capabilities depending on the connection role. For example, a device that acts as:
- Central when connecting to a keyboard (needs to display passkey)
- Peripheral when connecting to a PC (needs to enter passkey)

## Testing

Default implementations are provided for both new callbacks that inject passkey `123456`, maintaining backward compatibility.

## Backward Compatibility

✅ Fully backward compatible - existing code will continue to work with default implementations.
