### PR TITLE
Use designated initializer for NimBLEScan parameters and conditionally set disable_observer_mode

### DIFF
--- a/src/NimBLEScan.cpp
+++ b/src/NimBLEScan.cpp
@@ -41,7 +41,7 @@ NimBLEScan::NimBLEScan()
           .filter_duplicates = 1,                       // filter duplicates
 # if defined(ESP_PLATFORM) && !defined(CONFIG_USING_NIMBLE_COMPONENT)
 #  if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
-          .disable_observer_mode = 0,
+          .disable_observer_mode = 0, // observer role enabled
 #  endif
 # endif
       },


### PR DESCRIPTION
Use designated initializer for NimBLEScan::m_scanParams and guard disable_observer_mode field for ESP-IDF >= 5.4.2

The NimBLEScan constructor previously used positional struct initialization, which no longer matches the ble_gap_disc_params layout in newer ESP-IDF versions (>= 5.4.2) where the field `disable_observer_mode` was added.

This is caused by -Wmissing-field-initializers.

Switch to designated initializers to make the field assignments explicit and more robust across ESP-IDF/NimBLE revisions. The new field is only initialized when building against ESP-IDF 5.4.2 or later to maintain backwards compatibility.