### PR TITLE
[Bugfix] Set missing build flag for platformio builds

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,6 +9,11 @@
     "esp32",
     "nimble"
   ],
+  "build": {
+      "flags": [
+        "-DCONFIG_NIMBLE_CPP_IDF=1"
+      ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #407 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library build configuration with new compiler flags to enhance the build process and improve compilation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->