### PR TITLE
Doc: clarify NimBLEAddress(uint8_t[6], type) expects MSB-first bytes

### DIFF
--- a/src/NimBLEAddress.cpp
+++ b/src/NimBLEAddress.cpp
@@ -97,8 +97,19 @@ NimBLEAddress::NimBLEAddress(const std::string& addr, uint8_t type) {
 } // NimBLEAddress
 
 /**
- * @brief Constructor for compatibility with bluedroid esp library using native ESP representation.
- * @param [in] address A uint8_t[6] or esp_bd_addr_t containing the address.
+ * @brief Constructor accepting a 6-byte MSB-first BLE address (Bluedroid `esp_bd_addr_t` layout).
+ * @details The input bytes are stored internally in LSB-first wire
+ * order (NimBLE's `ble_addr_t.val` layout), so this constructor
+ * **reverses** the input. If you already have LSB-first wire bytes —
+ * e.g. straight out of a NimBLE callback's `ble_addr_t` — use the
+ * `NimBLEAddress(ble_addr_t)` constructor instead (it stores them
+ * as-is). If you have the address as a hex integer (e.g.
+ * `0xa4c1385def16` for `"a4:c1:38:5d:ef:16"`), use
+ * `NimBLEAddress(const uint64_t&, uint8_t)`.
+ * @param [in] address Six bytes in MSB-first order
+ *                     (`{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}` for
+ *                     `"aa:bb:cc:dd:ee:ff"`). Compatible with
+ *                     Bluedroid's `esp_bd_addr_t`.
  * @param [in] type The type of the address should be one of:
  * * BLE_ADDR_PUBLIC (0)
  * * BLE_ADDR_RANDOM (1)


### PR DESCRIPTION
Documentation-only follow-up to #423.

The byte-array `NimBLEAddress` constructor calls `std::reverse_copy` on its input — fine for callers passing Bluedroid-style MSB-first bytes (`esp_bd_addr_t`), but easy to miss for anyone arriving with LSB-first bytes (e.g. straight out of a NimBLE `ble_addr_t.val`) since both layouts are "native ESP." The original docstring said:

> Constructor for compatibility with bluedroid esp library using native ESP representation.

Updated docstring spells out the expected order, contrasts it with `NimBLEAddress(ble_addr_t)` for LSB-first wire bytes, and points hex-literal users at `NimBLEAddress(uint64_t, uint8_t)` (which is already well-documented).

No behaviour change.

## How this came up

Tracked down a 100% connect-timeout bug in a NimBLE bridge where I had a `uint64_t` MAC, converted to a `uint8_t[6]` in LSB-first wire order, and passed that to this constructor. `reverse_copy` then stored it MSB-first in `val[]`, NimBLE used `val[]` directly as the on-air LE bytes, and every `ble_gap_connect` timed out scanning for a peer that doesn't exist. Symptom was indistinguishable from "out of range." Switching to the `uint64_t` constructor fixed it immediately. Issue #423 has the full diagnostic story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved BLE address constructor documentation with enhanced clarity on byte order handling, parameter descriptions, and guidance on alternative constructors for different input formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h2zero/esp-nimble-cpp/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->