### PR TITLE
Restore GAP device name after GATT reset

### DIFF
--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -889,8 +889,21 @@ bool NimBLEServer::resetGATT() {
     NimBLEDevice::stopAdvertising();
 # endif
 
+    // esp-idf nimble clears the device name and
+    // appearance during ble_gatts_reset()
+#ifndef CONFIG_USING_NIMBLE_COMPONENT
+    std::string name(ble_svc_gap_device_name());
+    uint16_t appearance = ble_svc_gap_device_appearance();
+#endif
+
     ble_gatts_reset();
     ble_svc_gap_init();
+
+#ifndef CONFIG_USING_NIMBLE_COMPONENT
+    ble_svc_gap_device_name_set(name.c_str());
+    ble_svc_gap_device_appearance_set(appearance);
+#endif
+
     ble_svc_gatt_init();
 
     for (auto svcIt = m_svcVec.begin(); svcIt != m_svcVec.end();) {


### PR DESCRIPTION
NOTE: Codex 5.5 created this patch and writeup etc but I reviewed it and it looks like what I would have done by hand, and tested it here and it does resolve the issue and explains why I've been seeing my device misnamed for a bit. Not sure how or when I broke it, or if the issue was library side or a nimble change but figured others might be hitting this issue.


ESP-IDF NimBLE can reset the GAP Device Name when the standard GAP service is reinitialized during GATT server startup. NimBLEDevice::init(deviceName) calls NimBLEDevice::setDeviceName(deviceName), but that happens before the server is started. Later, starting advertising starts the server and resets/re-registers the GAP service, causing the C GAP name backing storage to be rebuilt from CONFIG_BT_NIMBLE_SVC_GAP_DEVICE_NAME. In projects where that Kconfig default remains "nimble", the advertised Local Name can be correct while the Generic Access Device Name characteristic reports "nimble".

The failing sequence is:

  -> pAdvertising->start()
     -> NimBLEAdvertising::start()
        -> NimBLEDevice::getServer()->start()
           -> NimBLEServer::resetGATT()
              -> ble_gatts_reset()
              -> ble_svc_gap_init()
                 -> ESP-IDF NimBLE resets GAP name to CONFIG_BT_NIMBLE_SVC_GAP_DEVICE_NAME
                 -> "nimble"
              -> ble_svc_gatt_init()

Fix this by saving the device name supplied through NimBLEDevice::setDeviceName() and reapplying it immediately after ble_svc_gap_init() in NimBLEServer::resetGATT(). This preserves the C++ wrapper contract that the configured device name remains effective even when the wrapper internally resets the GATT/GAP service tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the Bluetooth device name and appearance when the GATT server is reset, so these settings no longer revert unexpectedly after a reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->