### PR TITLE
Add onReadStatus/onWriteStatus callbacks so an application can reject a read/write with an ATT error

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -433,8 +433,16 @@ int NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
  * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
  */
 int NimBLECharacteristic::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
+    // Commit before the callback so getValue() reflects the new value inside it
+    // (onWriteStatus defaults to calling the legacy onWrite), but snapshot first
+    // so a rejected write can be rolled back and never becomes observable state.
+    NimBLEAttValue previous = m_value;
     setValue(val, len);
-    return m_pCallbacks->onWriteStatus(this, connInfo);
+    const int rc = m_pCallbacks->onWriteStatus(this, connInfo);
+    if (rc != 0) {
+        m_value = previous;
+    }
+    return rc;
 } // writeEvent
 
 /**

--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -422,8 +422,8 @@ void NimBLECharacteristic::updatePeerStatus(const NimBLEConnInfo& peerInfo) cons
  * @brief Handle a read event from a client.
  * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
  */
-void NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
-    m_pCallbacks->onRead(this, connInfo);
+int NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
+    return m_pCallbacks->onReadStatus(this, connInfo);
 } // readEvent
 
 /**
@@ -432,9 +432,9 @@ void NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
  * @param [in] len The length of the data written by the client.
  * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
  */
-void NimBLECharacteristic::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
+int NimBLECharacteristic::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
     setValue(val, len);
-    m_pCallbacks->onWrite(this, connInfo);
+    return m_pCallbacks->onWriteStatus(this, connInfo);
 } // writeEvent
 
 /**

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -271,8 +271,8 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     friend class NimBLEService;
 
     void setService(NimBLEService* pService);
-    void readEvent(NimBLEConnInfo& connInfo) override;
-    void writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) override;
+    int  readEvent(NimBLEConnInfo& connInfo) override;
+    int  writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) override;
     bool sendValue(const uint8_t* value,
                    size_t         length,
                    bool           is_notification = true,
@@ -319,6 +319,35 @@ class NimBLECharacteristicCallbacks {
     virtual ~NimBLECharacteristicCallbacks() {}
     virtual void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
     virtual void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo);
+
+    /**
+     * @brief Read request callback that can reject the read with an ATT error.
+     * @param [in] pCharacteristic The characteristic that is the source of the event.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
+     * @return 0 to accept the read, or a BLE_ATT_ERR_* code to reject it.
+     * @details Defaults to calling onRead() and accepting. Override this instead of onRead()
+     * when you need to reject a read from the application.
+     */
+    virtual int onReadStatus(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
+        onRead(pCharacteristic, connInfo);
+        return 0;
+    }
+
+    /**
+     * @brief Write request callback that can reject the write with an ATT error.
+     * @param [in] pCharacteristic The characteristic that is the source of the event.
+     * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
+     * @return 0 to accept the write, or a BLE_ATT_ERR_* code to reject it.
+     * @details Defaults to calling onWrite() and accepting. Override this instead of onWrite()
+     * when you need to reject a write from the application. A rejection only reaches the peer
+     * when it used write-with-response; a write-without-response (ATT Write Command) is
+     * unacknowledged, so the code is dropped by the stack.
+     */
+    virtual int onWriteStatus(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
+        onWrite(pCharacteristic, connInfo);
+        return 0;
+    }
+
     virtual void onStatus(NimBLECharacteristic* pCharacteristic, int code); // deprecated
     virtual void onStatus(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, int code);
     virtual void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue);

--- a/src/NimBLEDescriptor.cpp
+++ b/src/NimBLEDescriptor.cpp
@@ -120,13 +120,16 @@ std::string NimBLEDescriptor::toString() const {
     return res;
 } // toString
 
-void NimBLEDescriptor::readEvent(NimBLEConnInfo& connInfo) {
+int NimBLEDescriptor::readEvent(NimBLEConnInfo& connInfo) {
+    // Descriptor callbacks have no status-returning variant; always accept.
     m_pCallbacks->onRead(this, connInfo);
+    return 0;
 } // readEvent
 
-void NimBLEDescriptor::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
+int NimBLEDescriptor::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
     setValue(val, len);
     m_pCallbacks->onWrite(this, connInfo);
+    return 0;
 } // writeEvent
 
 /**

--- a/src/NimBLEDescriptor.h
+++ b/src/NimBLEDescriptor.h
@@ -49,8 +49,8 @@ class NimBLEDescriptor : public NimBLELocalValueAttribute {
     friend class NimBLEService;
 
     void setCharacteristic(NimBLECharacteristic* pChar);
-    void readEvent(NimBLEConnInfo& connInfo) override;
-    void writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) override;
+    int  readEvent(NimBLEConnInfo& connInfo) override;
+    int  writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) override;
 
     NimBLEDescriptorCallbacks* m_pCallbacks{nullptr};
     NimBLECharacteristic*      m_pCharacteristic{nullptr};

--- a/src/NimBLELocalValueAttribute.h
+++ b/src/NimBLELocalValueAttribute.h
@@ -112,8 +112,9 @@ class NimBLELocalValueAttribute : public NimBLELocalAttribute, public NimBLEValu
      * @brief Callback function to support a read request.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
      * @details This function is called by NimBLEServer when a read request is received.
+     * @return 0 on success, or a BLE_ATT_ERR_* code to reject the read.
      */
-    virtual void readEvent(NimBLEConnInfo& connInfo) = 0;
+    virtual int readEvent(NimBLEConnInfo& connInfo) = 0;
 
     /**
      * @brief Callback function to support a write request.
@@ -121,8 +122,9 @@ class NimBLELocalValueAttribute : public NimBLELocalAttribute, public NimBLEValu
      * @param [in] len The length of the value.
      * @param [in] connInfo A reference to a NimBLEConnInfo instance containing the peer info.
      * @details This function is called by NimBLEServer when a write request is received.
+     * @return 0 on success, or a BLE_ATT_ERR_* code to reject the write.
      */
-    virtual void writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) = 0;
+    virtual int writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) = 0;
 
     /**
      * @brief Get a pointer to value of the attribute.

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -742,7 +742,10 @@ int NimBLEServer::handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_
             // Don't call readEvent if the buffer len is 0 (this is a follow up to a previous read),
             // or if this is an internal read (handle is NONE)
             if (ctxt->om->om_len > 0 && connHandle != BLE_HS_CONN_HANDLE_NONE) {
-                pAtt->readEvent(peerInfo);
+                int appRc = pAtt->readEvent(peerInfo);
+                if (appRc != 0) {
+                    return appRc; // application rejected the read
+                }
             }
 
             ble_npl_hw_enter_critical();
@@ -773,8 +776,7 @@ int NimBLEServer::handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_
                 next  = SLIST_NEXT(next, om_next);
             }
 
-            pAtt->writeEvent(buf, len, peerInfo);
-            return 0;
+            return pAtt->writeEvent(buf, len, peerInfo);
         }
 
         default:


### PR DESCRIPTION
# Add onReadStatus/onWriteStatus callbacks so an application can reject a read/write with an ATT error

Addresses #428.

Short version of the problem (full detail in the issue): `onWrite()` returns `void`
and `handleGattEvent` hardcodes a success return on the write path, so there's no way
for an application to reject a write and have the peer receive an ATT error — even under
write-with-response, where the protocol allows it. The C host honors a non-zero return
from the access callback; the wrapper just doesn't expose that to application code.

## What this does

Adds two opt-in, status-returning callbacks to `NimBLECharacteristicCallbacks`:

```cpp
virtual int onReadStatus (NimBLECharacteristic*, NimBLEConnInfo&);
virtual int onWriteStatus(NimBLECharacteristic*, NimBLEConnInfo&);
```

Each returns `0` to accept or a `BLE_ATT_ERR_*` code to reject. Their default
implementations call the existing `onRead`/`onWrite` and return `0`, so behavior is
unchanged for anyone who doesn't override them. Internally the `readEvent`/`writeEvent`
chain (`NimBLELocalValueAttribute` → `NimBLECharacteristic`/`NimBLEDescriptor`) now
returns `int`, and `handleGattEvent` forwards that code to the host instead of always
returning `0`. On a rejected read it returns before appending the value.

Six files, +51/-15. No public signature changes to existing methods.

## Backward compatibility

Nothing existing changes shape. `onRead`/`onWrite` keep their `void` signatures, and
every current override keeps working untouched — the new `onReadStatus`/`onWriteStatus`
default to invoking them and accepting. It's purely additive.

I went with the additive form because it drops into a minor release without touching
anyone. That said — since master is already `3.0.0-dev`, if you'd rather take the cleaner
breaking version for the major (just change `onRead`/`onWrite` themselves to return `int`,
`0` = accept, and drop the separate status methods), I'm happy to reshape this into that.
It mirrors the C stack one-to-one; the only reason I didn't lead with it is the override
break. Your call on which fits 3.0 better.

## One caveat

A rejection only reaches the peer under write-with-response. A write-without-response
(ATT Write Command) is unacknowledged, so the stack drops the code and sends nothing —
that's per spec, not something this changes. Worth a mention in the docs so nobody expects
a rejection on a `WRITE_NO_RSP` characteristic.

Descriptors are compile-updated to the new `int` return but always accept; the same
`onWriteStatus`-style hook could be added to `NimBLEDescriptorCallbacks` later if there's
demand.

## Testing

Builds clean for `esp32s3`. I also validated it end-to-end on an ESP32-S3 with a macOS
central: a characteristic returning `BLE_ATT_ERR_INSUFFICIENT_RES` from `onWriteStatus`
surfaced on the central as `CBATTErrorDomain Code=17 "Resources are insufficient."` under
write-with-response, and produced no error under write-without-response — matching the
caveat above. Existing writes to unmodified characteristics were unaffected.

There's an open question from the issue worth settling here too: `writeEvent` commits
`setValue()` before the callback runs, so on a rejected write the local value has already
been updated. This PR keeps that ordering; if you'd prefer the pending `(data, len)` be
passed to `onWriteStatus` so an app can validate before commit, I can add that.

---

### AI usage disclosure

For transparency: I used an AI assistant while working on this — to help trace the call
path through the C host stack, cross-check the behavior against the source, and draft the
code. Flagging that so it's on the table. The changes are small and the cited code paths
point at specific locations, so they're straightforward to review against the tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read and write requests can now return ATT status codes to accept or reject operations.
  * Added characteristic callback hooks for read/write status codes (with default behavior that preserves existing callbacks).
* **Bug Fixes**
  * GATT handling now properly propagates application accept/reject results for reads and writes.
  * Descriptor and characteristic read/write handling now follows the status-based behavior, including reverting characteristic value changes when a write is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->