### PR TITLE
NimBLEAttValue.cpp - preserve capacity after realloc failure

### DIFF
--- a/src/NimBLEAttValue.cpp
+++ b/src/NimBLEAttValue.cpp
@@ -124,14 +124,18 @@ NimBLEAttValue& NimBLEAttValue::append(const uint8_t* value, uint16_t len) {
 
     uint8_t* res     = m_attr_value;
     uint16_t new_len = m_attr_len + len;
-    if (new_len > m_capacity) {
-        res        = static_cast<uint8_t*>(realloc(m_attr_value, (new_len + 1)));
-        m_capacity = new_len;
+    bool     grow    = new_len > m_capacity;
+    if (grow) {
+        res = static_cast<uint8_t*>(realloc(m_attr_value, (new_len + 1)));
     }
     NIMBLE_CPP_DEBUG_ASSERT(res);
     if (res == nullptr) {
         NIMBLE_LOGE(LOG_TAG, "Failed to realloc append");
         return *this;
+    }
+
+    if (grow) {
+        m_capacity = new_len;
     }
 
 # if MYNEWT_VAL(NIMBLE_CPP_ATT_VALUE_TIMESTAMP_ENABLED)


### PR DESCRIPTION
NimBLEAttValue::append advanced m_capacity immediately after calling realloc. If realloc failed, the original buffer remained allocated but the object advertised a larger capacity than it actually owned. A later append could then skip reallocation and copy past the end of the allocation.

Track whether the append actually needs growth and only update m_capacity after the realloc result passes the null check. Appends that fit the existing allocation leave capacity unchanged; failed growth preserves the old capacity invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data append behavior to better handle memory allocation failures.
  * Prevented internal capacity values from being updated when an expansion attempt fails, keeping state consistent and avoiding incorrect size reporting after errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->