### PR TITLE
[Bugfix] Stream available for write / Arduino memory release

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -54,6 +54,9 @@
 
 # if defined(ESP_PLATFORM) && defined(CONFIG_ENABLE_ARDUINO_DEPENDS)
 #  include "esp32-hal-bt.h"
+#  if __has_include("esp32-hal-bt-mem.h")
+#   include "esp32-hal-bt-mem.h"
+#  endif
 # endif
 
 # include "NimBLELog.h"

--- a/src/NimBLEStream.cpp
+++ b/src/NimBLEStream.cpp
@@ -356,8 +356,8 @@ size_t NimBLEStream::write(const uint8_t* data, size_t len) {
  * @brief Get the available free space in the stream's TX buffer.
  * @return the number of bytes that can be written to the stream without blocking.
  */
-size_t NimBLEStream::availableForWrite() const {
-    return m_txBuf ? m_txBuf->freeSize() : 0;
+int NimBLEStream::availableForWrite() {
+    return m_txBuf ? static_cast<int>(m_txBuf->freeSize()) : 0;
 }
 
 /**

--- a/src/NimBLEStream.h
+++ b/src/NimBLEStream.h
@@ -86,7 +86,7 @@ class NimBLEStream : public Stream {
         return write(static_cast<uint8_t>(data));
     }
 
-    size_t availableForWrite() const;
+    int availableForWrite();
 
     // Read up to len bytes into buffer (non-blocking)
     size_t read(uint8_t* buffer, size_t len);

--- a/src/NimBLEStream.h
+++ b/src/NimBLEStream.h
@@ -55,6 +55,7 @@ class Stream : public Print {
     virtual int   available() = 0;
     virtual int   read()      = 0;
     virtual int   peek()      = 0;
+    virtual int   availableForWrite() { return 0; }
     virtual void  flush() {}
     void          setTimeout(unsigned long timeout) { m_timeout = timeout; }
     unsigned long getTimeout() const { return m_timeout; }
@@ -86,7 +87,7 @@ class NimBLEStream : public Stream {
         return write(static_cast<uint8_t>(data));
     }
 
-    int availableForWrite();
+    int availableForWrite() override;
 
     // Read up to len bytes into buffer (non-blocking)
     size_t read(uint8_t* buffer, size_t len);


### PR DESCRIPTION
Fixes #432 
Fixes #433 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with supported ESP32 Arduino environments.
  * Updated stream buffer availability reporting to use the standard integer format.
  * Safely reports zero available write space when no transmission buffer is present.
  * Improved consistency for applications checking whether data can be written to a Bluetooth stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->