### PR TITLE
Initialize semaphore with braces in NimBLEUtils

### DIFF
--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -95,7 +95,7 @@ bool NimBLEUtils::taskWait(const TaskData& taskData, uint32_t timeout) {
     }
 
     if (taskData.m_pSem == nullptr) {
-        auto* sem = new ble_npl_sem;
+        auto* sem = new ble_npl_sem{};
         if (ble_npl_sem_init(sem, 0) != BLE_NPL_OK) {
             NIMBLE_LOGE(LOG_TAG, "Failed to initialize semaphore for taskWait");
             delete sem;


### PR DESCRIPTION
Fixes a connect crash in the client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization of internal semaphore objects without changing observable application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->