### PR TITLE
Fix NimBLEDevice::init() to check the return value from nimble_port_init().

### DIFF
--- a/src/NimBLEDevice.cpp
+++ b/src/NimBLEDevice.cpp
@@ -983,7 +983,15 @@ bool NimBLEDevice::init(const std::string& deviceName) {
 #   endif
 #  endif
 # endif
+# ifdef ESP_PLATFORM
+        esp_err_t rc = nimble_port_init();
+        NIMBLE_LOGE(LOG_TAG, "nimble_port_init rc=%d, npl_funcs=%p", rc, npl_funcs);
+        if (rc != ESP_OK) {
+            return false;
+        }
+# else
         nimble_port_init();
+# endif
 
         // Setup callbacks for host events
         ble_hs_cfg.reset_cb        = NimBLEDevice::onReset;

--- a/src/NimBLEUtils.cpp
+++ b/src/NimBLEUtils.cpp
@@ -95,7 +95,7 @@ bool NimBLEUtils::taskWait(const TaskData& taskData, uint32_t timeout) {
     }
 
     if (taskData.m_pSem == nullptr) {
-        auto* sem = new ble_npl_sem;
+        auto* sem = new ble_npl_sem{};
         if (ble_npl_sem_init(sem, 0) != BLE_NPL_OK) {
             NIMBLE_LOGE(LOG_TAG, "Failed to initialize semaphore for taskWait");
             delete sem;


### PR DESCRIPTION
Fix NimBLEDevice::init() to check the return value from nimble_port_init(). The result and npl_funcs pointer are logged for diagnostics, and initialization now returns false on failure instead of continuing with an invalid NimBLE state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization reliability on ESP platforms by detecting and reporting startup failures.
  * Initialization now correctly indicates when setup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->