### PR TITLE
fix: propagate application write rejections as ATT Error Responses

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -434,8 +434,29 @@ void NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
  */
 void NimBLECharacteristic::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
     setValue(val, len);
+    m_writeError = 0;
     m_pCallbacks->onWrite(this, connInfo);
 } // writeEvent
+
+/**
+ * @brief Set the ATT error code to return for the current write operation.
+ * @param [in] attError The ATT error code; 0 accepts the write. Use the
+ * Bluetooth-spec vendor-specific range 0x80-0x9F for application errors.
+ * Call this from your NimBLECharacteristicCallbacks::onWrite() implementation
+ * to reject the write; the stack will then send an ATT Error Response instead
+ * of a success response. Ignored for Write Commands (no response exists).
+ */
+void NimBLECharacteristic::setWriteError(uint8_t attError) {
+    m_writeError = attError;
+} // setWriteError
+
+/**
+ * @brief Get the write error code set by the onWrite callback.
+ * @return The ATT error code for the current write operation, 0 if none was set.
+ */
+int NimBLECharacteristic::getWriteError() const {
+    return m_writeError;
+} // getWriteError
 
 /**
  * @brief Set the callback handlers for this characteristic.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -76,6 +76,22 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
 
     NimBLECharacteristicCallbacks* getCallbacks() const;
 
+    /**
+     * @brief Set the ATT error code to return for the current write operation.
+     * @param [in] attError The ATT error code; 0 accepts the write. Use the
+     * Bluetooth-spec vendor-specific range 0x80-0x9F for application errors.
+     * Call this from your NimBLECharacteristicCallbacks::onWrite() implementation
+     * to reject the write; the stack will then send an ATT Error Response instead
+     * of a success response. Ignored for Write Commands (no response exists).
+     */
+    void setWriteError(uint8_t attError);
+
+    /**
+     * @brief Get the write error code set by the onWrite callback.
+     * @return The ATT error code for the current write operation, 0 if none was set.
+     */
+    int getWriteError() const;
+
     /*********************** Template Functions ************************/
 
 # if __cplusplus < 201703L
@@ -305,6 +321,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     NimBLEService*                 m_pService{nullptr};
     std::vector<NimBLEDescriptor*> m_vDescriptors{};
     mutable SubPeerArray           m_subPeers{};
+    int                            m_writeError = 0;
 }; // NimBLECharacteristic
 
 /**

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -18,6 +18,7 @@
 #include "NimBLEServer.h"
 #if CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
 
+# include "NimBLECharacteristic.h"
 # include "NimBLEDevice.h"
 # include "NimBLELog.h"
 
@@ -774,7 +775,8 @@ int NimBLEServer::handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_
             }
 
             pAtt->writeEvent(buf, len, peerInfo);
-            return 0;
+            // Only characteristics carry the write error slot; descriptor writes keep succeeding.
+            return ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR ? static_cast<NimBLECharacteristic*>(pAtt)->getWriteError() : 0;
         }
 
         default:


### PR DESCRIPTION
## Description

Closes #441.

`handleGattEvent`'s write branch hardcodes `return 0`, so an application that rejects a write inside `onWrite()` (busy, validation failure, ...) can never tell the client — the client always receives a successful Write Response. The NimBLE C stack supports ATT Error Responses from the access callback, and Write Requests (opcode 0x12) support them per spec; the capability is only lost in this wrapper.

Because `NimBLELocalValueAttribute::writeEvent` is a **pure virtual `void`** (overridden by both `NimBLECharacteristic` and `NimBLEDescriptor`), the error cannot be threaded through the existing signatures without a breaking API change. This PR therefore uses a **per-write error slot** on the characteristic — fully backwards compatible:

- `void NimBLECharacteristic::setWriteError(uint8_t attError)` — called by the application inside `onWrite()`; `0` accepts, vendor range `0x80`–`0x9F` for application-defined error codes.
- `int NimBLECharacteristic::getWriteError() const` — read by `handleGattEvent`, which returns the slot value on the `OP_WRITE_CHR` path and `0` on the `OP_WRITE_DSC` path.
- `writeEvent()` resets the slot to `0` before invoking `onWrite()`.

## Changes

| File | Change |
|------|--------|
| `src/NimBLECharacteristic.h` | public `setWriteError` / `getWriteError`, private `int m_writeError = 0` |
| `src/NimBLECharacteristic.cpp` | reset slot in `writeEvent` before `onWrite`; two method implementations |
| `src/NimBLEServer.cpp` | write branch returns the slot via an op-guarded cast (DSC/CHR share one case block; the guard keeps descriptor writes succeeding) |

No existing signature, virtual, or behavior changes for applications that don't call `setWriteError`.

## Client-visible behavior

- Write **Request** (opcode 0x12) with a non-zero slot → the stack sends an **ATT Error Response** with that code. Android surfaces it as a non-`GATT_SUCCESS` status in `onCharacteristicWrite`; iOS as an error in `peripheral:didWriteValueForCharacteristic:error:`.
- Write **Command** (0x52, no response) has no response to carry the error — unchanged (documented in the header comment).

## Known pre-existing behavior (unchanged, for the record)

- `writeEvent` applies `setValue(val, len)` before invoking `onWrite`, so a *rejected* write still updates the locally stored attribute value. This predates this PR; an ATT Error Response tells the client to treat the value as unchanged, and a rollback pass is left out of scope here.

## Validation

- The identical patch, backported to the 2.5.0 branch, is compiled and shipping in a downstream ESP-IDF 5.5.4 / ESP32-S3 product (component-manager build + 727 host-side unit tests, including new tests for the reject/accept paths).
- This branch applies the same patch to `master` (identical code context); it has not been compiled against 3.0.0-dev independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write-validation error handling for characteristic callbacks.
  * Applications can now report an ATT error when a characteristic write is rejected.
  * Write errors reset for each new write, preventing stale errors from affecting later requests.
  * Write Commands continue to be accepted without returning an ATT error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->