### PR TITLE
feat(NimBLEServer): add registerServicesFirst() to place app services at low handles

### DIFF
--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -966,6 +966,12 @@ bool NimBLEServer::resetGATT() {
         if (pSvc->getRemoved() == 0) {
             if (!pSvc->start_internal()) {
                 NIMBLE_LOGE(LOG_TAG, "Failed to start service: %s", pSvc->getUUID().toString().c_str());
+                // When deferring GAP/GATT (registerServicesFirst), still register
+                // them on the failure path so the mandatory GAP/GATT services (and
+                // the restored name/appearance) are never left out of the database.
+                if (m_registerServicesFirst) {
+                    initGapGattServices();
+                }
                 return false;
             }
         }

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -54,6 +54,7 @@ NimBLEServer::NimBLEServer()
     : m_gattsStarted{false},
       m_svcChanged{false},
       m_deleteCallbacks{false},
+      m_registerServicesFirst{false},
 # if !MYNEWT_VAL(BLE_EXT_ADV)
       m_advertiseOnDisconnect{false},
 # endif
@@ -365,6 +366,20 @@ void NimBLEServer::advertiseOnDisconnect(bool enable) {
     m_advertiseOnDisconnect = enable;
 } // advertiseOnDisconnect
 # endif
+
+/**
+ * @brief Register the application's services before the standard GAP/GATT services.
+ * @param [in] enable true == register the application services first (they take the
+ * low attribute handles, starting at 0x0001, and GAP/GATT are placed after them);
+ * false (default) == the standard behavior, GAP/GATT register first and take the low
+ * handles.
+ * @details Must be called before the services are started (i.e. before
+ * NimBLEServer::start()). Useful when a peripheral must expose a fixed attribute-table
+ * layout that another device relies on by hardcoded handle rather than discovery.
+ */
+void NimBLEServer::registerServicesFirst(bool enable) {
+    m_registerServicesFirst = enable;
+} // registerServicesFirst
 
 /**
  * @brief Return the number of connected clients.
@@ -897,14 +912,24 @@ bool NimBLEServer::resetGATT() {
 #endif
 
     ble_gatts_reset();
-    ble_svc_gap_init();
 
+    // Register the standard GAP (0x1800) and GATT (0x1801) services, restoring the
+    // device name/appearance that ble_gatts_reset() clears. By default this happens
+    // first, so GAP/GATT take the low attribute handles (0x0001+). When
+    // registerServicesFirst() is enabled, it is deferred until after the application
+    // services below, so those take the low handles instead.
+    auto initGapGattServices = [&]() {
+        ble_svc_gap_init();
 #ifndef CONFIG_USING_NIMBLE_COMPONENT
-    ble_svc_gap_device_name_set(name.c_str());
-    ble_svc_gap_device_appearance_set(appearance);
+        ble_svc_gap_device_name_set(name.c_str());
+        ble_svc_gap_device_appearance_set(appearance);
 #endif
+        ble_svc_gatt_init();
+    };
 
-    ble_svc_gatt_init();
+    if (!m_registerServicesFirst) {
+        initGapGattServices();
+    }
 
     for (auto svcIt = m_svcVec.begin(); svcIt != m_svcVec.end();) {
         auto* pSvc = *svcIt;
@@ -947,6 +972,10 @@ bool NimBLEServer::resetGATT() {
 
         pSvc->m_handle = 0;
         ++svcIt;
+    }
+
+    if (m_registerServicesFirst) {
+        initGapGattServices();
     }
 
     return true;

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -54,7 +54,7 @@ NimBLEServer::NimBLEServer()
     : m_gattsStarted{false},
       m_svcChanged{false},
       m_deleteCallbacks{false},
-      m_registerServicesFirst{false},
+      m_registerAppServicesFirst{false},
 # if !MYNEWT_VAL(BLE_EXT_ADV)
       m_advertiseOnDisconnect{false},
 # endif
@@ -377,9 +377,9 @@ void NimBLEServer::advertiseOnDisconnect(bool enable) {
  * NimBLEServer::start()). Useful when a peripheral must expose a fixed attribute-table
  * layout that another device relies on by hardcoded handle rather than discovery.
  */
-void NimBLEServer::registerServicesFirst(bool enable) {
-    m_registerServicesFirst = enable;
-} // registerServicesFirst
+void NimBLEServer::registerAppServicesFirst(bool enable) {
+    m_registerAppServicesFirst = enable;
+} // registerAppServicesFirst
 
 /**
  * @brief Return the number of connected clients.
@@ -916,7 +916,7 @@ bool NimBLEServer::resetGATT() {
     // Register the standard GAP (0x1800) and GATT (0x1801) services, restoring the
     // device name/appearance that ble_gatts_reset() clears. By default this happens
     // first, so GAP/GATT take the low attribute handles (0x0001+). When
-    // registerServicesFirst() is enabled, it is deferred until after the application
+    // registerAppServicesFirst() is enabled, it is deferred until after the application
     // services below, so those take the low handles instead.
     auto initGapGattServices = [&]() {
         ble_svc_gap_init();
@@ -927,7 +927,7 @@ bool NimBLEServer::resetGATT() {
         ble_svc_gatt_init();
     };
 
-    if (!m_registerServicesFirst) {
+    if (!m_registerAppServicesFirst) {
         initGapGattServices();
     }
 
@@ -966,10 +966,10 @@ bool NimBLEServer::resetGATT() {
         if (pSvc->getRemoved() == 0) {
             if (!pSvc->start_internal()) {
                 NIMBLE_LOGE(LOG_TAG, "Failed to start service: %s", pSvc->getUUID().toString().c_str());
-                // When deferring GAP/GATT (registerServicesFirst), still register
+                // When deferring GAP/GATT (registerAppServicesFirst), still register
                 // them on the failure path so the mandatory GAP/GATT services (and
                 // the restored name/appearance) are never left out of the database.
-                if (m_registerServicesFirst) {
+                if (m_registerAppServicesFirst) {
                     initGapGattServices();
                 }
                 return false;
@@ -980,7 +980,7 @@ bool NimBLEServer::resetGATT() {
         ++svcIt;
     }
 
-    if (m_registerServicesFirst) {
+    if (m_registerAppServicesFirst) {
         initGapGattServices();
     }
 

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -81,7 +81,7 @@ class NimBLEServer {
     NimBLEConnInfo        getPeerInfo(const NimBLEAddress& address) const;
     NimBLEConnInfo        getPeerInfoByHandle(uint16_t connHandle) const;
     void                  advertiseOnDisconnect(bool enable);
-    void                  registerServicesFirst(bool enable);
+    void                  registerAppServicesFirst(bool enable);
     void                  setDataLen(uint16_t connHandle, uint16_t tx_octets) const;
     bool                  updatePhy(uint16_t connHandle, uint8_t txPhysMask, uint8_t rxPhysMask, uint16_t phyOptions);
     bool                  getPhy(uint16_t connHandle, uint8_t* txPhy, uint8_t* rxPhy);
@@ -130,7 +130,7 @@ class NimBLEServer {
     bool m_gattsStarted : 1;
     bool m_svcChanged : 1;
     bool m_deleteCallbacks : 1;
-    bool m_registerServicesFirst : 1;
+    bool m_registerAppServicesFirst : 1;
 # if !MYNEWT_VAL(BLE_EXT_ADV) && MYNEWT_VAL(BLE_ROLE_BROADCASTER)
     bool m_advertiseOnDisconnect : 1;
 # endif

--- a/src/NimBLEServer.h
+++ b/src/NimBLEServer.h
@@ -81,6 +81,7 @@ class NimBLEServer {
     NimBLEConnInfo        getPeerInfo(const NimBLEAddress& address) const;
     NimBLEConnInfo        getPeerInfoByHandle(uint16_t connHandle) const;
     void                  advertiseOnDisconnect(bool enable);
+    void                  registerServicesFirst(bool enable);
     void                  setDataLen(uint16_t connHandle, uint16_t tx_octets) const;
     bool                  updatePhy(uint16_t connHandle, uint8_t txPhysMask, uint8_t rxPhysMask, uint16_t phyOptions);
     bool                  getPhy(uint16_t connHandle, uint8_t* txPhy, uint8_t* rxPhy);
@@ -129,6 +130,7 @@ class NimBLEServer {
     bool m_gattsStarted : 1;
     bool m_svcChanged : 1;
     bool m_deleteCallbacks : 1;
+    bool m_registerServicesFirst : 1;
 # if !MYNEWT_VAL(BLE_EXT_ADV) && MYNEWT_VAL(BLE_ROLE_BROADCASTER)
     bool m_advertiseOnDisconnect : 1;
 # endif


### PR DESCRIPTION
## Summary

Adds an opt-in `NimBLEServer::registerServicesFirst(bool)` setter that registers
the application's services **before** the standard GAP (`0x1800`) and GATT
(`0x1801`) services, so the application services take the low attribute handles
(starting at `0x0001`) and GAP/GATT are placed last.

## Motivation

By default GAP/GATT register first and occupy `0x0001+`, which shifts the
application's services to higher handles. That's fine when the peer discovers
handles — but some centrals address a peripheral's attributes by **hardcoded
handle** and never perform full discovery. Emulating such a device (in my case a
Nintendo game controller, whose console writes to fixed handles like `0x0016`
and expects notifications on `0x001e`) requires the vendor services to sit at the
low handles exactly like the real device.

Today this isn't possible without patching the library.

## What changed

- New `NimBLEServer::registerServicesFirst(bool enable)` (default `false`), a
  `bool m_registerServicesFirst : 1` bitfield, and its initialization — mirroring
  the existing `advertiseOnDisconnect()` pattern.
- In `resetGATT()`, the GAP/GATT init (and the device-name/appearance restore
  that follows `ble_gatts_reset()`) is factored into a small lambda and invoked
  either before the application-service loop (default) or after it (when enabled).

## Compatibility

Non-breaking: the flag defaults to `false`, so the existing handle layout and
behavior are unchanged unless an application explicitly opts in. Must be called
before `NimBLEServer::start()`.

## Testing

Built against ESP-IDF (NimBLE) and used end-to-end in a project that emulates a
BLE game controller: with the flag enabled, the vendor services land at the
expected low handles and the peer connects/pairs by hardcoded handle; with it
disabled, behavior is identical to before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether standard GAP/GATT services are registered before or after application services.
  * Application services can receive lower GATT attribute handles when registered first.
  * Registration order can be configured through the server API using the updated application-services-first option.

* **Bug Fixes**
  * Ensured required GAP/GATT services and restored device information remain available when application service registration fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->