### PR TITLE
fix: propagate application write rejections as ATT Error Responses (backport to 2.5)

### DIFF
--- a/src/NimBLECharacteristic.cpp
+++ b/src/NimBLECharacteristic.cpp
@@ -434,8 +434,29 @@ void NimBLECharacteristic::readEvent(NimBLEConnInfo& connInfo) {
  */
 void NimBLECharacteristic::writeEvent(const uint8_t* val, uint16_t len, NimBLEConnInfo& connInfo) {
     setValue(val, len);
+    m_writeError = 0;
     m_pCallbacks->onWrite(this, connInfo);
 } // writeEvent
+
+/**
+ * @brief Set the ATT error code to return for the current write operation.
+ * @param [in] attError The ATT error code; 0 accepts the write. Use the
+ * Bluetooth-spec vendor-specific range 0x80-0x9F for application errors.
+ * Call this from your NimBLECharacteristicCallbacks::onWrite() implementation
+ * to reject the write; the stack will then send an ATT Error Response instead
+ * of a success response. Ignored for Write Commands (no response exists).
+ */
+void NimBLECharacteristic::setWriteError(uint8_t attError) {
+    m_writeError = attError;
+} // setWriteError
+
+/**
+ * @brief Get the write error code set by the onWrite callback.
+ * @return The ATT error code for the current write operation, 0 if none was set.
+ */
+int NimBLECharacteristic::getWriteError() const {
+    return m_writeError;
+} // getWriteError
 
 /**
  * @brief Set the callback handlers for this characteristic.

--- a/src/NimBLECharacteristic.h
+++ b/src/NimBLECharacteristic.h
@@ -76,6 +76,22 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
 
     NimBLECharacteristicCallbacks* getCallbacks() const;
 
+    /**
+     * @brief Set the ATT error code to return for the current write operation.
+     * @param [in] attError The ATT error code; 0 accepts the write. Use the
+     * Bluetooth-spec vendor-specific range 0x80-0x9F for application errors.
+     * Call this from your NimBLECharacteristicCallbacks::onWrite() implementation
+     * to reject the write; the stack will then send an ATT Error Response instead
+     * of a success response. Ignored for Write Commands (no response exists).
+     */
+    void setWriteError(uint8_t attError);
+
+    /**
+     * @brief Get the write error code set by the onWrite callback.
+     * @return The ATT error code for the current write operation, 0 if none was set.
+     */
+    int getWriteError() const;
+
     /*********************** Template Functions ************************/
 
 # if __cplusplus < 201703L
@@ -305,6 +321,7 @@ class NimBLECharacteristic : public NimBLELocalValueAttribute {
     NimBLEService*                 m_pService{nullptr};
     std::vector<NimBLEDescriptor*> m_vDescriptors{};
     mutable SubPeerArray           m_subPeers{};
+    int                            m_writeError = 0;
 }; // NimBLECharacteristic
 
 /**

--- a/src/NimBLEServer.cpp
+++ b/src/NimBLEServer.cpp
@@ -18,6 +18,7 @@
 #include "NimBLEServer.h"
 #if CONFIG_BT_NIMBLE_ENABLED && MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
 
+# include "NimBLECharacteristic.h"
 # include "NimBLEDevice.h"
 # include "NimBLELog.h"
 
@@ -774,7 +775,8 @@ int NimBLEServer::handleGattEvent(uint16_t connHandle, uint16_t attrHandle, ble_
             }
 
             pAtt->writeEvent(buf, len, peerInfo);
-            return 0;
+            // Only characteristics carry the write error slot; descriptor writes keep succeeding.
+            return ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR ? static_cast<NimBLECharacteristic*>(pAtt)->getWriteError() : 0;
         }
 
         default:


### PR DESCRIPTION
Backport of #442 to the release/2.5 branch.

## Summary
This backports the fix for propagating application-layer write rejections as ATT Error Responses to the 2.5 release branch.

## Changes
- NimBLECharacteristic: Added setWriteError(uint8_t) and getWriteError() const methods
- NimBLECharacteristic::writeEvent(): Resets error slot before each write
- NimBLEServer::handleGattEvent(): Returns the write error for characteristic writes (descriptor writes still return 0)

## Usage
Applications can now reject writes in onWrite() callbacks:

```cpp
void MyCallbacks::onWrite(NimBLECharacteristic* pChar, NimBLEConnInfo& connInfo) {
    if (deviceBusy) {
        pChar->setWriteError(0x80); // vendor-specific error code
        return;
    }
    // process write normally
}
```

## Testing
- Verified compile against ESP-IDF 5.x
- Verified the write error is correctly returned to the BLE client as ATT Error Response

@h2zero - this is the backport requested in #442 comment. Would appreciate a review/merge when you have cycles.
